### PR TITLE
Restore SIMD support in vector.

### DIFF
--- a/source/tit/core/simd/traits.hpp
+++ b/source/tit/core/simd/traits.hpp
@@ -21,6 +21,12 @@ namespace tit::simd {
 template<class Num>
 concept supported_type = std::integral<Num> || std::floating_point<Num>;
 
+/// Evaluate the following command block if SIMD is supported for the given
+/// type and if the code is not executed at compile-time.
+#define TIT_IF_SIMD_AVALIABLE(Num)                                             \
+  if constexpr (simd::supported_type<Num>)                                     \
+    if !consteval
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Minimal byte width of the SIMD register that is available on the current

--- a/source/tit/core/vec/traits.hpp
+++ b/source/tit/core/vec/traits.hpp
@@ -3,6 +3,7 @@
  * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
 \* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+// IWYU pragma: private, include "tit/core/vec.hpp"
 #pragma once
 
 #include <type_traits>

--- a/source/tit/core/vec/vec.hpp
+++ b/source/tit/core/vec/vec.hpp
@@ -15,6 +15,7 @@
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
 #include "tit/core/math.hpp"
+#include "tit/core/simd.hpp"
 #include "tit/core/utils.hpp"
 #include "tit/core/vec/vec_mask.hpp"
 
@@ -63,6 +64,128 @@ private:
 
 }; // class Vec
 
+/// Column vector with SIMD support.
+template<simd::supported_type Num, size_t Dim>
+class Vec<Num, Dim> final {
+public:
+
+  /// Type of the underlying register that is used.
+  using Reg = simd::deduce_reg_t<Num, Dim>;
+
+  /// Size of the underlying register that is used.
+  static constexpr auto RegSize = simd::deduce_size_v<Num, Dim>;
+
+  /// Amount of the underlying registers stored.
+  static constexpr auto RegCount = simd::deduce_count_v<Num, Dim>;
+
+  // NOLINTBEGIN(*-type-union-access)
+
+  /// Fill-initialize the vector with zeroes.
+  constexpr Vec() noexcept {
+    if consteval {
+      col_ = fill_array<Dim>(Num{0});
+    } else {
+      regs_ = fill_array<RegCount>(Reg{});
+    }
+  }
+
+  /// Fill-initialize the vector with the value @p q.
+  constexpr explicit(Dim > 1) Vec(Num q) noexcept {
+    if consteval {
+      col_ = fill_array<Dim>(q);
+    } else {
+      regs_ = fill_array<RegCount>(Reg(q));
+    }
+  }
+
+  /// Construct a vector with elements @p qs.
+  template<class... Args>
+    requires (Dim > 1) && (sizeof...(Args) == Dim) &&
+             (std::constructible_from<Num, Args &&> && ...)
+  constexpr Vec(Args&&... qs) // NOSONAR
+      : col_{make_array<Dim, Num>(std::forward<Args>(qs)...)} {}
+
+  /// Move-construct the vector.
+  constexpr Vec(Vec&& other) noexcept {
+    if consteval {
+      col_ = std::move(other.col_);
+    } else {
+      regs_ = std::move(other.regs_);
+    }
+  }
+
+  /// Move-assign the vector.
+  constexpr auto operator=(Vec&& other) noexcept -> Vec& {
+    if consteval {
+      col_ = std::move(other.col_);
+    } else {
+      regs_ = std::move(other.regs_);
+    }
+    return *this;
+  }
+
+  /// Copy-construct the vector.
+  constexpr Vec(const Vec& other) {
+    if consteval {
+      col_ = other.col_;
+    } else {
+      regs_ = other.regs_;
+    }
+  }
+
+  /// Copy-assign the vector.
+  constexpr auto operator=(const Vec& other) -> Vec& { // NOLINT(cert-oop54-cpp)
+    if consteval {
+      col_ = other.col_;
+    } else {
+      regs_ = other.regs_;
+    }
+    return *this;
+  }
+
+  /// Destroy the vector.
+  constexpr ~Vec() = default;
+
+  /// Vector dimensionality.
+  constexpr auto dim() const -> ssize_t {
+    return Dim;
+  }
+
+  /// Element at index.
+  /// @{
+  constexpr auto operator[](size_t i) noexcept -> Num& {
+    TIT_ASSERT(i < Dim, "Row index is out of range!");
+    return col_[i];
+  }
+  constexpr auto operator[](size_t i) const noexcept -> const Num& {
+    TIT_ASSERT(i < Dim, "Row index is out of range!");
+    return col_[i];
+  }
+  /// @}
+
+  /// Underlying register at index.
+  /// @{
+  auto reg(size_t i) noexcept -> Reg& {
+    TIT_ASSERT(i < RegCount, "Register index is out of range!");
+    return regs_[i];
+  }
+  auto reg(size_t i) const noexcept -> const Reg& {
+    TIT_ASSERT(i < RegCount, "Register index is out of range!");
+    return regs_[i];
+  }
+  /// @}
+
+  // NOLINTEND(*-type-union-access)
+
+private:
+
+  union {
+    std::array<Num, Dim> col_{};
+    std::array<Reg, RegCount> regs_;
+  };
+
+}; // class Vec<SIMD>
+
 template<class Num, class... RestNums>
 Vec(Num, RestNums...) -> Vec<Num, 1 + sizeof...(RestNums)>;
 
@@ -89,6 +212,12 @@ template<class Num, size_t Dim>
 constexpr auto minimum(const Vec<Num, Dim>& a,
                        const Vec<Num, Dim>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::min(a.reg(i), b.reg(i));
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = std::min(a[i], b[i]);
   return r;
 }
@@ -98,6 +227,12 @@ template<class Num, size_t Dim>
 constexpr auto maximum(const Vec<Num, Dim>& a,
                        const Vec<Num, Dim>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::max(a.reg(i), b.reg(i));
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = std::max(a[i], b[i]);
   return r;
 }
@@ -107,6 +242,12 @@ template<class Num, size_t Dim>
 constexpr auto filter(const VecMask<Num, Dim>& m,
                       const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::filter(m.reg(i), a.reg(i));
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = m[i] ? a[i] : Num{0};
   return r;
 }
@@ -117,6 +258,12 @@ constexpr auto select(const VecMask<Num, Dim>& m,
                       const Vec<Num, Dim>& a,
                       const Vec<Num, Dim>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::select(m.reg(i), a.reg(i), b.reg(i));
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = m[i] ? a[i] : b[i];
   return r;
 }
@@ -138,6 +285,12 @@ template<class Num, size_t Dim>
 constexpr auto operator+(const Vec<Num, Dim>& a,
                          const Vec<Num, Dim>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = a.reg(i) + b.reg(i);
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = a[i] + b[i];
   return r;
 }
@@ -146,6 +299,10 @@ constexpr auto operator+(const Vec<Num, Dim>& a,
 template<class Num, size_t Dim>
 constexpr auto operator+=(Vec<Num, Dim>& a,
                           const Vec<Num, Dim>& b) -> Vec<Num, Dim>& {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) a.reg(i) += b.reg(i);
+    return a;
+  }
   for (size_t i = 0; i < Dim; ++i) a[i] += b[i];
   return a;
 }
@@ -154,6 +311,10 @@ constexpr auto operator+=(Vec<Num, Dim>& a,
 template<class Num, size_t Dim>
 constexpr auto operator-(const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) r.reg(i) = -a.reg(i);
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = -a[i];
   return r;
 }
@@ -163,6 +324,12 @@ template<class Num, size_t Dim>
 constexpr auto operator-(const Vec<Num, Dim>& a,
                          const Vec<Num, Dim>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = a.reg(i) - b.reg(i);
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = a[i] - b[i];
   return r;
 }
@@ -171,6 +338,10 @@ constexpr auto operator-(const Vec<Num, Dim>& a,
 template<class Num, size_t Dim>
 constexpr auto operator-=(Vec<Num, Dim>& a,
                           const Vec<Num, Dim>& b) -> Vec<Num, Dim>& {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) a.reg(i) -= b.reg(i);
+    return a;
+  }
   for (size_t i = 0; i < Dim; ++i) a[i] -= b[i];
   return a;
 }
@@ -186,6 +357,13 @@ template<class Num, size_t Dim>
 constexpr auto operator*(const Vec<Num, Dim>& a,
                          const std::type_identity_t<Num>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    const typename Vec<Num, Dim>::Reg b_reg(b);
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = a.reg(i) * b_reg;
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = a[i] * b;
   return r;
 }
@@ -195,6 +373,11 @@ constexpr auto operator*(const Vec<Num, Dim>& a,
 template<class Num, size_t Dim>
 constexpr auto operator*=(Vec<Num, Dim>& a, const std::type_identity_t<Num>& b)
     -> Vec<Num, Dim>& {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    const typename Vec<Num, Dim>::Reg b_reg(b);
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) a.reg(i) *= b_reg;
+    return a;
+  }
   for (size_t i = 0; i < Dim; ++i) a[i] *= b;
   return a;
 }
@@ -204,6 +387,12 @@ template<class Num, size_t Dim>
 constexpr auto operator*(const Vec<Num, Dim>& a,
                          const Vec<Num, Dim>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = a.reg(i) * b.reg(i);
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = a[i] * b[i];
   return r;
 }
@@ -212,6 +401,10 @@ constexpr auto operator*(const Vec<Num, Dim>& a,
 template<class Num, size_t Dim>
 constexpr auto operator*=(Vec<Num, Dim>& a,
                           const Vec<Num, Dim>& b) -> Vec<Num, Dim>& {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) a.reg(i) *= b.reg(i);
+    return a;
+  }
   for (size_t i = 0; i < Dim; ++i) a[i] *= b[i];
   return a;
 }
@@ -238,6 +431,12 @@ template<class Num, size_t Dim>
 constexpr auto operator/(const Vec<Num, Dim>& a,
                          const Vec<Num, Dim>& b) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = a.reg(i) / b.reg(i);
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = a[i] / b[i];
   return r;
 }
@@ -246,6 +445,10 @@ constexpr auto operator/(const Vec<Num, Dim>& a,
 template<class Num, size_t Dim>
 constexpr auto operator/=(Vec<Num, Dim>& a,
                           const Vec<Num, Dim>& b) -> Vec<Num, Dim>& {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) a.reg(i) /= b.reg(i);
+    return a;
+  }
   for (size_t i = 0; i < Dim; ++i) a[i] /= b[i];
   return a;
 }
@@ -259,6 +462,12 @@ constexpr auto operator/=(Vec<Num, Dim>& a,
 template<class Num, size_t Dim>
 constexpr auto floor(const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::floor(a.reg(i));
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = floor(a[i]);
   return r;
 }
@@ -267,6 +476,12 @@ constexpr auto floor(const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
 template<class Num, size_t Dim>
 constexpr auto round(const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::round(a.reg(i));
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = round(a[i]);
   return r;
 }
@@ -275,6 +490,12 @@ constexpr auto round(const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
 template<class Num, size_t Dim>
 constexpr auto ceil(const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
   Vec<Num, Dim> r;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::ceil(a.reg(i));
+    }
+    return r;
+  }
   for (size_t i = 0; i < Dim; ++i) r[i] = ceil(a[i]);
   return r;
 }
@@ -289,6 +510,12 @@ template<class Num, size_t Dim>
 constexpr auto operator==(const Vec<Num, Dim>& a,
                           const Vec<Num, Dim>& b) -> VecMask<Num, Dim> {
   VecMask<Num, Dim> m;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      m.reg(i) = a.reg(i) == b.reg(i);
+    }
+    return m;
+  }
   for (size_t i = 0; i < Dim; ++i) m[i] = a[i] == b[i];
   return m;
 }
@@ -298,6 +525,12 @@ template<class Num, size_t Dim>
 constexpr auto operator!=(const Vec<Num, Dim>& a,
                           const Vec<Num, Dim>& b) -> VecMask<Num, Dim> {
   VecMask<Num, Dim> m;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      m.reg(i) = a.reg(i) != b.reg(i);
+    }
+    return m;
+  }
   for (size_t i = 0; i < Dim; ++i) m[i] = a[i] != b[i];
   return m;
 }
@@ -307,6 +540,12 @@ template<class Num, size_t Dim>
 constexpr auto operator<(const Vec<Num, Dim>& a,
                          const Vec<Num, Dim>& b) -> VecMask<Num, Dim> {
   VecMask<Num, Dim> m;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      m.reg(i) = a.reg(i) < b.reg(i);
+    }
+    return m;
+  }
   for (size_t i = 0; i < Dim; ++i) m[i] = a[i] < b[i];
   return m;
 }
@@ -316,6 +555,12 @@ template<class Num, size_t Dim>
 constexpr auto operator<=(const Vec<Num, Dim>& a,
                           const Vec<Num, Dim>& b) -> VecMask<Num, Dim> {
   VecMask<Num, Dim> m;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      m.reg(i) = a.reg(i) <= b.reg(i);
+    }
+    return m;
+  }
   for (size_t i = 0; i < Dim; ++i) m[i] = a[i] <= b[i];
   return m;
 }
@@ -342,6 +587,17 @@ constexpr auto operator>=(const Vec<Num, Dim>& a,
 /// Sum of the vector elements.
 template<class Num, size_t Dim>
 constexpr auto sum(const Vec<Num, Dim>& a) -> Num {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    constexpr auto RegSize = Vec<Num, Dim>::RegSize;
+    constexpr auto FullRegCount = Dim / RegSize;
+    if constexpr (FullRegCount > 0) {
+      auto r_reg = a.reg(0);
+      for (size_t i = 1; i < FullRegCount; ++i) r_reg += a.reg(i);
+      auto r = simd::sum(r_reg);
+      for (size_t i = FullRegCount * RegSize; i < Dim; ++i) r += a[i];
+      return r;
+    }
+  }
   auto r = a[0];
   for (size_t i = 1; i < Dim; ++i) r += a[i];
   return r;
@@ -350,6 +606,21 @@ constexpr auto sum(const Vec<Num, Dim>& a) -> Num {
 /// Minimal vector element.
 template<class Num, size_t Dim>
 constexpr auto min_value(const Vec<Num, Dim>& a) -> Num {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    constexpr auto RegSize = Vec<Num, Dim>::RegSize;
+    constexpr auto FullRegCount = Dim / RegSize;
+    if constexpr (FullRegCount > 0) {
+      auto r_reg = a.reg(0);
+      for (size_t i = 1; i < FullRegCount; ++i) {
+        r_reg = simd::min(r_reg, a.reg(i));
+      }
+      auto r = simd::min_value(r_reg);
+      for (size_t i = FullRegCount * RegSize; i < Dim; ++i) {
+        r = std::min(r, a[i]);
+      }
+      return r;
+    }
+  }
   auto r = a[0];
   for (size_t i = 1; i < Dim; ++i) r = std::min(r, a[i]);
   return r;
@@ -358,6 +629,22 @@ constexpr auto min_value(const Vec<Num, Dim>& a) -> Num {
 /// Maximal vector element.
 template<class Num, size_t Dim>
 constexpr auto max_value(const Vec<Num, Dim>& a) -> Num {
+  using std::max;
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    constexpr auto RegSize = Vec<Num, Dim>::RegSize;
+    constexpr auto FullRegCount = Dim / RegSize;
+    if constexpr (FullRegCount > 0) {
+      auto r_reg = a.reg(0);
+      for (size_t i = 1; i < FullRegCount; ++i) {
+        r_reg = simd::max(r_reg, a.reg(i));
+      }
+      auto r = simd::max_value(r_reg);
+      for (size_t i = FullRegCount * RegSize; i < Dim; ++i) {
+        r = std::max(r, a[i]);
+      }
+      return r;
+    }
+  }
   auto r = a[0];
   for (size_t i = 1; i < Dim; ++i) r = std::max(r, a[i]);
   return r;
@@ -391,6 +678,19 @@ constexpr auto max_value_index(const Vec<Num, Dim>& a) -> size_t {
 /// Vector dot product.
 template<class Num, size_t Dim>
 constexpr auto dot(const Vec<Num, Dim>& a, const Vec<Num, Dim>& b) -> Num {
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    constexpr auto RegSize = Vec<Num, Dim>::RegSize;
+    constexpr auto FullRegCount = Dim / RegSize;
+    if constexpr (FullRegCount > 0) {
+      auto r_reg = a.reg(0) * b.reg(0);
+      for (size_t i = 1; i < FullRegCount; ++i) {
+        r_reg = simd::fma(a.reg(i), b.reg(i), r_reg);
+      }
+      auto r = simd::sum(r_reg);
+      for (size_t i = FullRegCount * RegSize; i < Dim; ++i) r += a[i] * b[i];
+      return r;
+    }
+  }
   auto r = a[0] * b[0];
   for (size_t i = 1; i < Dim; ++i) r += a[i] * b[i];
   return r;
@@ -415,6 +715,17 @@ constexpr auto normalize(const Vec<Num, Dim>& a) -> Vec<Num, Dim> {
   if constexpr (Dim == 1) return is_tiny(a[0]) ? Num{0} : sign(a[0]);
   const auto norm_sqr = norm2(a);
   constexpr auto eps_sqr = pow2(tiny_number_v<Num>);
+  TIT_IF_SIMD_AVALIABLE(Num) {
+    // Use blending since we are most likely deal with a non-zero vector.
+    using Reg = typename Vec<Num, Dim>::Reg;
+    const auto has_dir_reg = Reg(norm_sqr) >= Reg(eps_sqr);
+    const Reg norm_recip_reg(rsqrt(norm_sqr));
+    Vec<Num, Dim> r;
+    for (size_t i = 0; i < Vec<Num, Dim>::RegCount; ++i) {
+      r.reg(i) = simd::filter(has_dir_reg, a.reg(i) * norm_recip_reg);
+    }
+    return r;
+  }
   const auto has_dir = norm_sqr >= pow2(eps_sqr);
   return has_dir ? a * rsqrt(norm_sqr) : Vec<Num, Dim>{};
 }

--- a/source/tit/core/vec/vec.test.cpp
+++ b/source/tit/core/vec/vec.test.cpp
@@ -245,18 +245,28 @@ TEST_CASE_TEMPLATE("Vec::sum", Num, NUM_TYPES) {
   CHECK(sum(Vec{Num{1}, Num{2}, Num{3}}) == Num{6});
   CHECK(sum(Vec{Num{1}, Num{2}, Num{3}, Num{4}}) == Num{10});
   CHECK(sum(Vec{Num{1}, Num{2}, Num{3}, Num{4}, Num{5}}) == Num{15});
+  // To cover all the SIMD paths, 17 element vectors are needed.
+  CHECK(sum(Vec<Num, 17>(Num{16})) == Num{17 * 16});
 }
 
 TEST_CASE_TEMPLATE("Vec::min_value", Num, NUM_TYPES) {
   CHECK(min_value(Vec{Num{3}, Num{2}, Num{4}}) == Num{2});
   CHECK(min_value(Vec{Num{5}, Num{4}, Num{6}, Num{3}}) == Num{3});
   CHECK(min_value(Vec{Num{5}, Num{4}, Num{6}, Num{2}, Num{3}}) == Num{2});
+  // To cover all the SIMD paths, 17 element vectors are needed.
+  Vec<Num, 17> v(Num{16});
+  v[8] = Num{1};
+  CHECK(min_value(v) == Num{1});
 }
 
 TEST_CASE_TEMPLATE("Vec::max_value", Num, NUM_TYPES) {
   CHECK(max_value(Vec{Num{3}, Num{2}, Num{4}}) == Num{4});
   CHECK(max_value(Vec{Num{5}, Num{4}, Num{6}, Num{3}}) == Num{6});
   CHECK(max_value(Vec{Num{5}, Num{4}, Num{6}, Num{2}, Num{3}}) == Num{6});
+  // To cover all the SIMD paths, 17 element vectors are needed.
+  Vec<Num, 17> v(Num{16});
+  v[8] = Num{17};
+  CHECK(max_value(v) == Num{17});
 }
 
 TEST_CASE_TEMPLATE("Vec::min_value_index", Num, NUM_TYPES) {
@@ -285,6 +295,8 @@ TEST_CASE_TEMPLATE("Vec::dot", Num, NUM_TYPES) {
             Vec{Num{5}, Num{6}, Num{7}, Num{8}}) == Num{70});
   CHECK(dot(Vec{Num{1}, Num{2}, Num{3}, Num{4}, Num{5}},
             Vec{Num{6}, Num{7}, Num{8}, Num{9}, Num{10}}) == Num{130});
+  // To cover all the SIMD paths, 17 element vectors are needed.
+  CHECK(dot(Vec<Num, 17>(Num{3}), Vec<Num, 17>(Num{4})) == Num{17 * 3 * 4});
 }
 
 TEST_CASE_TEMPLATE("Vec::norm2", Num, NUM_TYPES) {

--- a/source/tit/core/vec/vec_mask.test.cpp
+++ b/source/tit/core/vec/vec_mask.test.cpp
@@ -97,18 +97,34 @@ TEST_CASE_TEMPLATE("VecMask::operator!=", Num, NUM_TYPES) {
 //
 
 TEST_CASE_TEMPLATE("VecMask::all_and_any", Num, NUM_TYPES) {
+  // To cover all the SIMD paths, 17 element vectors are needed.
   SUBCASE("all") {
-    const auto m = VecMask<Num, 2>{true, true};
+    const VecMask<Num, 17> m(true);
     CHECK(any(m));
     CHECK(all(m));
   }
   SUBCASE("some") {
-    const auto m = VecMask<Num, 2>{false, true};
-    CHECK(any(m));
-    CHECK_FALSE(all(m));
+    SUBCASE("true in registers") {
+      VecMask<Num, 17> m(false);
+      m[9] = true;
+      CHECK(any(m));
+      CHECK_FALSE(all(m));
+    }
+    SUBCASE("true in remainder") {
+      VecMask<Num, 17> m(false);
+      m[16] = true;
+      CHECK(any(m));
+      CHECK_FALSE(all(m));
+    }
+    SUBCASE("false in remainder") {
+      VecMask<Num, 17> m(true);
+      m[16] = false;
+      CHECK(any(m));
+      CHECK_FALSE(all(m));
+    }
   }
   SUBCASE("none") {
-    const auto m = VecMask<Num, 2>{false, false};
+    const VecMask<Num, 17> m(false);
     CHECK_FALSE(any(m));
     CHECK_FALSE(all(m));
   }


### PR DESCRIPTION
Before:
```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
    140.94906        100.00000            1    main
    131.43758         93.25183        34130    tit::EulerIntegrator::step()
     54.08215         38.36999         3413    tit::ParticleAdjacency::build()
     40.26822         28.56934        34130    tit::FluidEquations::compute_density()
     18.93333         13.43275        34130    tit::FluidEquations::compute_forces()
     15.79256         11.20444        34130    tit::FluidEquations::setup_boundary()
      3.15812          2.24061         3413    tit::ZCurveOrdering::ZCurveOrdering()
      0.93584          0.66395         3413    tit::Grid::Grid()
      0.00019          0.00014            1    tit::FluidEquations::init()
--------------------------------------------------------------------------------
```

After:
```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
    125.11854        100.00000            1    main
    115.57488         92.37231        34130    tit::EulerIntegrator::step()
     51.32585         41.02178         3413    tit::ParticleAdjacency::build()
     31.82788         25.43818        34130    tit::FluidEquations::compute_density()
     15.90254         12.70998        34130    tit::FluidEquations::compute_forces()
     14.07130         11.24638        34130    tit::FluidEquations::setup_boundary()
      3.15357          2.52047         3413    tit::ZCurveOrdering::ZCurveOrdering()
      0.93189          0.74480         3413    tit::Grid::Grid()
      0.00014          0.00011            1    tit::FluidEquations::init()
--------------------------------------------------------------------------------
```