### PR TITLE
Clean-up miscellaneous utilities in `tit/par`.

### DIFF
--- a/source/tit/core/math.hpp
+++ b/source/tit/core/math.hpp
@@ -13,10 +13,10 @@
 #include <limits>
 #include <ranges>
 #include <type_traits>
-#include <utility>
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
+#include "tit/core/type_traits.hpp"
 #include "tit/core/utils.hpp"
 
 namespace tit {
@@ -29,28 +29,6 @@ using std::floor;
 using std::round;
 using std::sin;
 using std::sqrt;
-
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-/// Negation result type.
-template<class Num>
-using negate_result_t = decltype(-std::declval<Num>());
-
-/// Addition result type.
-template<class NumA, class NumB = NumA>
-using add_result_t = decltype(std::declval<NumA>() + std::declval<NumB>());
-
-/// Subtraction result type.
-template<class NumA, class NumB = NumA>
-using sub_result_t = decltype(std::declval<NumA>() - std::declval<NumB>());
-
-/// Multiplication result type.
-template<class NumA, class NumB = NumA>
-using mul_result_t = decltype(std::declval<NumA>() * std::declval<NumB>());
-
-/// Division result type.
-template<class NumA, class NumB = NumA>
-using div_result_t = decltype(std::declval<NumA>() / std::declval<NumB>());
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/tit/core/multivector.hpp
+++ b/source/tit/core/multivector.hpp
@@ -114,7 +114,7 @@ public:
     par::for_each(handles, [&](auto handle) {
       size_t const index = index_of(handle);
       TIT_ASSERT(index < count, "Index of the value is out of expected range.");
-      par::sync_fetch_and_add(val_ranges_[index + 1], 1);
+      par::fetch_and_add(val_ranges_[index + 1], 1);
     });
     /// Perform a partial sum of the computed values to form ranges.
     for (size_t index = 2; index < val_ranges_.size(); ++index) {
@@ -128,7 +128,7 @@ public:
     par::for_each(handles, [&](auto handle) {
       auto const index = index_of(handle);
       TIT_ASSERT(index < count, "Index of the value is out of expected range.");
-      auto const addr = par::sync_fetch_and_add(val_ranges_[index], 1);
+      auto const addr = par::fetch_and_add(val_ranges_[index], 1);
       vals_[addr] = value_of(handle);
     });
     /// Fix value ranges, since after incrementing the entire array is shifted

--- a/source/tit/core/type_traits.hpp
+++ b/source/tit/core/type_traits.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <utility>
+
 namespace tit {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -25,6 +27,28 @@ inline constexpr bool is_specialization_of_v<T<Args...>, T> = true;
 /// Check if type is a specialization of the given template.
 template<class Type, template<class...> class Template>
 concept specialization_of = impl::is_specialization_of_v<Type, Template>;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Negation result type.
+template<class Num>
+using negate_result_t = decltype(-std::declval<Num>());
+
+/// Addition result type.
+template<class NumA, class NumB = NumA>
+using add_result_t = decltype(std::declval<NumA>() + std::declval<NumB>());
+
+/// Subtraction result type.
+template<class NumA, class NumB = NumA>
+using sub_result_t = decltype(std::declval<NumA>() - std::declval<NumB>());
+
+/// Multiplication result type.
+template<class NumA, class NumB = NumA>
+using mul_result_t = decltype(std::declval<NumA>() * std::declval<NumB>());
+
+/// Division result type.
+template<class NumA, class NumB = NumA>
+using div_result_t = decltype(std::declval<NumA>() / std::declval<NumB>());
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/tit/geom/hilbert_ordering.hpp
+++ b/source/tit/geom/hilbert_ordering.hpp
@@ -17,7 +17,7 @@
 
 #include "tit/geom/bbox.hpp"
 
-#include "tit/par/thread.hpp"
+#include "tit/par/task_group.hpp"
 
 #include <oneapi/tbb/task_group.h>
 

--- a/source/tit/geom/kd_tree.hpp
+++ b/source/tit/geom/kd_tree.hpp
@@ -21,7 +21,7 @@
 #include "tit/geom/bbox.hpp"
 
 #include "tit/par/memory_pool.hpp"
-#include "tit/par/thread.hpp"
+#include "tit/par/task_group.hpp"
 
 namespace tit::geom {
 

--- a/source/tit/geom/kd_tree.hpp
+++ b/source/tit/geom/kd_tree.hpp
@@ -126,7 +126,7 @@ private:
     TIT_ASSERT(first != nullptr && first < last, "Invalid subtree range.");
     // Allocate node.
     // TODO: We are not correctly initializing `node`.
-    auto const node = pool_.allocate(1);
+    auto const node = pool_.create();
     auto const actual_bbox = subtree_bbox_</*Parallel=*/IsRoot>(first, last);
     if constexpr (IsRoot) bbox = actual_bbox;
     // Is leaf node reached?

--- a/source/tit/par/CMakeLists.txt
+++ b/source/tit/par/CMakeLists.txt
@@ -11,6 +11,7 @@ add_tit_library(
     "control.cpp"
     "control.hpp"
     "memory_pool.hpp"
+    "task_group.hpp"
     "thread.hpp"
   DEPENDS
     tit::core)
@@ -24,6 +25,7 @@ add_tit_executable(
     "atomic.test.cpp"
     "control.test.cpp"
     "memory_pool.test.cpp"
+    "task_group.test.cpp"
   DEPENDS
     tit::par tit::testing)
 

--- a/source/tit/par/CMakeLists.txt
+++ b/source/tit/par/CMakeLists.txt
@@ -21,6 +21,7 @@ add_tit_executable(
   NAME
     par_tests
   SOURCES
+    "atomic.test.cpp"
     "control.test.cpp"
     "memory_pool.test.cpp"
   DEPENDS

--- a/source/tit/par/atomic.test.cpp
+++ b/source/tit/par/atomic.test.cpp
@@ -3,24 +3,26 @@
  * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
 \* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#pragma once
+#include "tit/par/atomic.hpp"
 
-#include <concepts>
-#include <type_traits>
+#include "tit/testing/test.hpp"
 
-#include "tit/core/type_traits.hpp"
-
-namespace tit::par {
+namespace tit {
+namespace {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Atomically perform addition and return what was stored before.
-template<class Val>
-  requires std::integral<Val> || std::is_pointer_v<Val>
-auto fetch_and_add(Val& val, sub_result_t<Val> delta) noexcept -> Val {
-  return __sync_fetch_and_add(&val, delta); // NOLINT(*-vararg)
+TEST_CASE("par::fetch_and_add") {
+  constexpr auto init = 0xDEAD;
+  constexpr auto delta = 0xBEEF;
+  auto val = init;
+  // Ensure we are getting back the original value.
+  CHECK(par::fetch_and_add(val, delta) == init);
+  // Ensure that the value was updated correctly.
+  CHECK(val == init + delta);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-} // namespace tit::par
+} // namespace
+} // namespace tit

--- a/source/tit/par/memory_pool.hpp
+++ b/source/tit/par/memory_pool.hpp
@@ -9,10 +9,12 @@
 #include <memory>
 #include <type_traits>
 
+#ifndef TBB_PREVIEW_MEMORY_POOL
 #define TBB_PREVIEW_MEMORY_POOL 1
+#endif
+
 #include <oneapi/tbb/memory_pool.h>
 
-#include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
 
 namespace tit::par {
@@ -21,58 +23,35 @@ namespace tit::par {
 
 /// Thread-safe and scalable memory pool (arena).
 template<class Val>
-  requires std::is_object_v<Val>
+  requires std::is_object_v<Val> && std::is_trivially_destructible_v<Val>
 class MemoryPool final {
-private:
-
-  // Unfortunately, `tbb::memory_pool` is not "movable" nor "move_constructible"
-  // due to it's implementation details. It is not even "relocatable": it's
-  // implementation relies on it's own address. In order to make our class
-  // movable, I'll play safe and wrap it into the unique pointer.
-  using TbbMemoryPool_ = tbb::memory_pool<std::allocator<Val>>;
-  std::unique_ptr<TbbMemoryPool_> pool_{};
-  static_assert(
-      !std::movable<TbbMemoryPool_>,
-      "A reminder to update implementation once memory pool becomes movable.");
-
 public:
 
-  /// Construct the memory pool with specified allocator.
-  MemoryPool() : pool_{new TbbMemoryPool_{}} {}
-
-  /// Move-construct the memory pool.
-  MemoryPool(MemoryPool&&) = default;
-
-  /// Move-assign the pool allocator.
-  auto operator=(MemoryPool&&) -> MemoryPool& = default;
-
-  /// Memory pool is not copy-constructible.
-  MemoryPool(MemoryPool const&) = delete;
-
-  /// Memory pool is not copyable.
-  auto operator=(MemoryPool const&) -> MemoryPool& = delete;
-
-  /// Destroy memory pool and free all memory.
-  ~MemoryPool() = default;
-
-  /// Allocate the specified amount of values.
+  /// Allocate and initialize the new value from @p args.
   ///
-  /// @note Values are not initialized: no constructors are called!
   /// @returns Pointer to the allocated memory or `nullptr`.
+  template<class... Args>
+    requires std::constructible_from<Val, Args&&...>
   [[nodiscard]]
-  auto allocate(size_t count = 1) -> Val* {
+  auto create(Args&&... args) -> Val* {
     TIT_ASSERT(pool_ != nullptr, "Memory pool was moved away!");
-    auto const num_bytes = count * sizeof(Val);
-    return static_cast<Val*>(pool_->malloc(num_bytes));
+    auto* const ptr = static_cast<Val*>(pool_->malloc(sizeof(Val)));
+    if (ptr != nullptr) std::construct_at(ptr, std::forward<Args>(args)...);
+    return ptr;
   }
 
   /// Free memory that was previously allocated inside of the current pool.
   ///
   /// @note Values are not deinitialized: no destructors are called!
-  void deallocate(Val* pointer) {
+  void destroy(Val* pointer) {
     TIT_ASSERT(pool_ != nullptr, "Memory pool was moved away!");
     pool_->free(pointer);
   }
+
+private:
+
+  std::unique_ptr<tbb::memory_pool<std::allocator<Val>>> pool_ =
+      std::make_unique<typename decltype(pool_)::element_type>();
 
 }; // class MemoryPool
 

--- a/source/tit/par/memory_pool.test.cpp
+++ b/source/tit/par/memory_pool.test.cpp
@@ -3,13 +3,7 @@
  * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
 \* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
-#include <algorithm>
-#include <array>
-#include <limits>
-#include <thread>
-#include <utility>
-
-#include "tit/core/basic_types.hpp"
+#include <future>
 
 #include "tit/par/memory_pool.hpp"
 
@@ -20,126 +14,54 @@ namespace {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+struct Node {
+  int data = -1;
+  Node* left = nullptr;
+  Node* right = nullptr;
+};
+
+auto make_tree_async(int i, int n, par::MemoryPool<Node>* pool) -> Node* {
+  // Allocate the node.
+  auto* const node = pool->create(10 * i);
+  if (n == 1) {
+    // Reached leaf node.
+    node->left = node->right = nullptr;
+  } else {
+    // Spawn new tasks.
+    auto left_future = std::async(&make_tree_async, i * 2, n / 2, pool);
+    auto right_future = std::async(&make_tree_async, i * 2 + 1, n / 2, pool);
+    left_future.wait();
+    right_future.wait();
+    node->left = left_future.get();
+    node->right = right_future.get();
+  }
+  return node;
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 TEST_CASE("par::MemoryPool") {
-  SUBCASE("basic") {
-    // Create memory pool.
-    par::MemoryPool<int> pool{};
-    // Check that basic allocations work.
-    constexpr size_t count = 1024;
-    auto* data = pool.allocate(count);
-    CHECK(data != nullptr);
-    // Check that the memory is accessible.
-    std::fill_n(data, count, 1234);
-    // Deallocate the data.
-    pool.deallocate(data);
-  }
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  SUBCASE("no construction") {
-    // A class that triggers failure inside of it's constructors or destructor.
-    struct NonConstructible {
-      NonConstructible() = delete;
-    };
-    // Create memory pool.
-    par::MemoryPool<NonConstructible> pool{};
-    // Allocate the data.
-    auto* data = pool.allocate(1);
-    // Deallocate the data.
-    pool.deallocate(data);
-  }
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  SUBCASE("allocate too much") {
-    // Create memory pool.
-    par::MemoryPool<int> pool{};
-    // Try to allocate too much memory and expect `nullptr` to be returned.
-    constexpr auto too_much = std::numeric_limits<tit::size_t>::max();
-    CHECK(pool.allocate(too_much) == nullptr);
-  }
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  SUBCASE("move") {
-    // Create memory pool.
-    par::MemoryPool<int> pool{};
-    // Allocate a single value and assign the value to it.
-    constexpr auto val = 1234;
-    auto* data = pool.allocate(1);
-    *data = val;
-    // Move pool into a different variable and check if the data is
-    // still accessible.
-    auto pool2(std::move(pool));
-    CHECK(*data == val);
-    // Move pool back and check the data again.
-    pool = std::move(pool2);
-    CHECK(*data == val);
-  }
-
-  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  SUBCASE("parallel linked list tests") {
-    // Pool allocators are mostly used for building some tree-like structures
-    // in parallel. This test is an attempt to recreate this use case: generate
-    // a linked list in parallel storing the N consecutive numbers.
-    struct ListNode {
-      tit::size_t magic;
-      tit::size_t value;
-      ListNode* next;
-    };
-    // Creates threads that generate a linked list storing a portion of
-    // consecutive numbers. The actual nodes will be stored inside of a pool
-    // allocator. Each node is also equipped with the magic number.
-    constexpr auto magic = 15241094284759029579UZ;
-    constexpr auto num_threads = 4UZ;
-    constexpr auto num_nodes = 1024UZ;
-    par::MemoryPool<ListNode> pool{};
-    std::array<ListNode*, num_threads> all_lists{};
-    std::array<std::thread, num_threads> threads{};
-    auto const main_thread_id = std::this_thread::get_id();
-    for (auto thread_index = 0UZ; thread_index < num_threads; ++thread_index) {
-      threads[thread_index] = std::thread([&, thread_index] {
-        // Check that we are actually inside of the separate thread.
-        auto const current_thread_id = std::this_thread::get_id();
-        CHECK(main_thread_id != current_thread_id);
-        // Generate nodes that store our portion of the consecutive numbers.
-        ListNode* list = nullptr;
-        for (auto node_index = 0UZ; node_index < num_nodes; ++node_index) {
-          /// Allocate the node.
-          auto* node = pool.allocate(1);
-          /// Assign the magic number.
-          node->magic = magic;
-          /// Assign the next consecutive number.
-          node->value = thread_index * num_nodes + node_index;
-          /// Append the current node into the linked list.
-          node->next = list;
-          list = node;
-        }
-        // Append our sublist into the global list.
-        all_lists[thread_index] = list;
-      });
-    }
-    // Join the threads once they finish.
-    for (auto& thread : threads) thread.join();
-    // Check that amount of nodes and sum of the list elements matches the
-    // expected results. Expected sum is just a sum of the arithmetic
-    // progression. Also check that the magic number is preserved.
-    constexpr auto expected_amount = num_threads * num_nodes;
-    constexpr auto expected_sum = expected_amount * (expected_amount - 1) / 2;
-    auto actual_amount = 0UZ;
-    auto actual_sum = 0UZ;
-    for (auto* list : all_lists) {
-      CHECK(list != nullptr);
-      for (auto* node = list; node != nullptr; node = node->next) {
-        CHECK(node->magic == magic);
-        actual_amount += 1;
-        actual_sum += node->value;
-      }
-    }
-    CHECK(actual_amount == expected_amount);
-    CHECK(actual_sum == expected_sum);
-  }
+  // Generate a tree in parallel.
+  par::MemoryPool<Node> pool{};
+  auto* const root = make_tree_async(0, 4, &pool);
+  // Ensure all the memory is allocated correctly.
+  REQUIRE(root != nullptr);
+  REQUIRE(root->left != nullptr);
+  REQUIRE(root->left->left != nullptr);
+  REQUIRE(root->left->right != nullptr);
+  REQUIRE(root->right != nullptr);
+  REQUIRE(root->right->left != nullptr);
+  REQUIRE(root->right->right != nullptr);
+  // Check that all the values are correct.
+  CHECK(root->data == 0);
+  CHECK(root->left->data == 0);
+  CHECK(root->left->left->data == 0);
+  CHECK(root->left->right->data == 10);
+  CHECK(root->right->data == 10);
+  CHECK(root->right->left->data == 20);
+  CHECK(root->right->right->data == 30);
+  // Free the memory (most likely does nothing).
+  pool.destroy(root);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/par/task_group.hpp
+++ b/source/tit/par/task_group.hpp
@@ -1,0 +1,74 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <concepts>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <oneapi/tbb/parallel_invoke.h>
+#include <oneapi/tbb/task_group.h>
+
+#include "tit/core/checks.hpp"
+
+namespace tit::par {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Task function.
+template<class Task>
+concept task =
+    std::invocable<Task> && std::same_as<std::invoke_result_t<Task>, void>;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Parallel task group.
+class TaskGroup final {
+public:
+
+  /// Run the task.
+  /// @{
+  template<class Task>
+    requires task<Task&&>
+  void run(Task&& task) {
+    TIT_ASSERT(group_ != nullptr, "Task group was moved away!");
+    group_->run(std::forward<Task>(task));
+  }
+  template<class Task>
+    requires task<Task&&>
+  void run(bool parallel, Task&& task) {
+    TIT_ASSERT(group_ != nullptr, "Task group was moved away!");
+    if (parallel) group_->run(std::forward<Task>(task));
+    else std::invoke(std::forward<Task>(task));
+  }
+  /// @}
+
+  /// Wait for the group to finish.
+  void wait() {
+    TIT_ASSERT(group_ != nullptr, "Task group was moved away!");
+    this->group_->wait();
+  }
+
+private:
+
+  std::unique_ptr<tbb::task_group> group_ =
+      std::make_unique<typename decltype(group_)::element_type>();
+
+}; // class TaskGroup
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Invoke functions in parallel.
+template<class... Tasks>
+  requires (task<Tasks &&> && ...)
+constexpr void invoke(Tasks&&... tasks) noexcept {
+  tbb::parallel_invoke(std::forward<Tasks>(tasks)...);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace tit::par

--- a/source/tit/par/task_group.test.cpp
+++ b/source/tit/par/task_group.test.cpp
@@ -1,0 +1,84 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <utility>
+
+#include "tit/par/control.hpp"
+#include "tit/par/task_group.hpp"
+
+#include "tit/testing/test.hpp"
+
+namespace tit {
+namespace {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("par::TaskGroup") {
+  // Explicitly enable parallelism.
+  par::set_num_threads(4);
+  SUBCASE("basic") {
+    // Run the parallel tasks and record IDs of the worker threads.
+    std::mutex mutex{};
+    std::set<std::thread::id> worker_thread_ids{};
+    auto const main_thread_id = std::this_thread::get_id();
+    // Create the task group and run the tasks.
+    par::TaskGroup group{};
+    for (int i = 0; i < 20; ++i) {
+      // Define the task.
+      auto const parallel = i % 10 != 0;
+      auto task = [&, parallel] {
+        // Pretend we are doing some work.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        // Check parallelism.
+        auto const this_thread_id = std::this_thread::get_id();
+        if (parallel) {
+          // Record ID of the current thread.
+          std::scoped_lock const lock{mutex};
+          worker_thread_ids.insert(this_thread_id);
+        } else {
+          // Ensure sequential tasks run on the main thread.
+          CHECK(this_thread_id == main_thread_id);
+        }
+      };
+      // Use different overloads of the `run` method.
+      if (parallel && i % 2 == 0) group.run(std::move(task));
+      else group.run(parallel, std::move(task));
+    }
+    // Ensure the tasks have finished.
+    group.wait();
+    REQUIRE(!worker_thread_ids.empty());
+    // Ensure the tasks have been executed in parallel.
+    CHECK(worker_thread_ids.size() > 1);
+  }
+  SUBCASE("exceptions") {
+    try {
+      par::TaskGroup group{};
+      for (int i = 0; i < 20; ++i) {
+        group.run([i] {
+          // Pretend we are doing some work.
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          // Some of the tasks will throw an exception.
+          if (i == 14) throw std::runtime_error{"Task failed!"};
+        });
+      }
+      // Ensure the tasks have finished.
+      group.wait();
+      FAIL("Task should have thrown an exception!");
+    } catch (std::runtime_error const& e) {
+      // Ensure the exception was caught.
+      CHECK(std::strcmp(e.what(), "Task failed!") == 0);
+    }
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace
+} // namespace tit

--- a/source/tit/par/thread.hpp
+++ b/source/tit/par/thread.hpp
@@ -6,19 +6,18 @@
 #pragma once
 
 #include <algorithm>
-#include <concepts>
 #include <cstdint>
 #include <ranges>
+
+#include <oneapi/tbb/blocked_range.h>
+#include <oneapi/tbb/parallel_for.h>
+#include <oneapi/tbb/partitioner.h>
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
 
 #include "tit/par/control.hpp"
-
-#include <oneapi/tbb/blocked_range.h>
-#include <oneapi/tbb/parallel_for.h>
-#include <oneapi/tbb/parallel_invoke.h>
-#include <oneapi/tbb/partitioner.h>
+#include "tit/par/task_group.hpp"
 
 namespace tit::par {
 
@@ -37,12 +36,6 @@ inline auto thread_index() noexcept -> size_t {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-/// Invoke functions in parallel (inside the current process).
-template<std::invocable... Funcs>
-constexpr void invoke(Funcs&&... funcs) noexcept {
-  tbb::parallel_invoke(funcs...);
-}
 
 /// Iterate through the range in parallel (dynamic partitioning).
 /// @{


### PR DESCRIPTION
Performance (main):

```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
    146.92671        100.00000            1    main
    137.38715         93.50726        34129    tit::EulerIntegrator::step()
     53.91006         36.69181         3413    tit::ParticleAdjacency::build()
     45.88795         31.23186        34129    tit::FluidEquations::compute_density()
     18.66362         12.70267        34129    tit::FluidEquations::compute_forces()
     16.76435         11.41001        34129    tit::FluidEquations::setup_boundary()
      3.19876          2.17711         3413    tit::ZCurveOrdering::ZCurveOrdering()
      0.96594          0.65743         3413    tit::Grid::Grid()
      0.00014          0.00010            1    tit::FluidEquations::init()
--------------------------------------------------------------------------------
```

Performance (future implementation):

```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
    142.49330        100.00000            1    main
    132.89901         93.26685        34129    tit::EulerIntegrator::step()
     51.66324         36.25661         3413    tit::ParticleAdjacency::build()
     43.98456         30.86781        34129    tit::FluidEquations::compute_density()
     18.19892         12.77178        34129    tit::FluidEquations::compute_forces()
     16.79811         11.78870        34129    tit::FluidEquations::setup_boundary()
      0.99306          0.69692         3413    tit::Grid::Grid()
      0.91822          0.64439         3413    MortonCurveOrdering::ctor()
      0.00017          0.00012            1    tit::FluidEquations::init()
--------------------------------------------------------------------------------
```