### PR TITLE
Fix performance after upgrading to GCC 14.

### DIFF
--- a/source/tit/core/checks.hpp
+++ b/source/tit/core/checks.hpp
@@ -14,15 +14,16 @@
 ///
 /// Do not use this macro for user input, but just to check the internal logic.
 /// If the expression does not hold, the entire process is aborted (in constant
-/// evaluation context compilation is aborted).
+/// evaluation context, compilation is aborted).
 #define TIT_ENSURE(expr, message) tit::impl::run_check((expr), (#expr), message)
 
 /// Check that the given expression holds (in debug mode).
 ///
-/// In release mode this macro hints the compiler that the given check always
-/// holds, thus opening a possibility for extra optimization.
+/// Do not use this macro for user input, but just to check the internal logic.
+/// If the expression does not hold, the entire process is aborted (in constant
+/// evaluation context, compilation is aborted).
 #ifdef NDEBUG
-#define TIT_ASSERT(expr, message) [[assume((expr))]]
+#define TIT_ASSERT(expr, message) static_cast<void>(expr)
 #else
 #define TIT_ASSERT(expr, message) TIT_ENSURE((expr), (message))
 #endif

--- a/source/tit/core/multivector.hpp
+++ b/source/tit/core/multivector.hpp
@@ -119,7 +119,7 @@ public:
     // Compute value ranges.
     /// First compute how many values there are per each index.
     val_ranges_.clear(), val_ranges_.resize(count + 1);
-    par::static_for_each(handles, [&](auto const& handle) {
+    par::for_each(handles, [&](auto const& handle) {
       auto const index = static_cast<size_t>(index_of(handle));
       TIT_ASSERT(index < count, "Index of the value is out of expected range!");
       par::fetch_and_add(val_ranges_[index + 1], 1);
@@ -133,7 +133,7 @@ public:
     /// then increment the position.
     auto const num_vals = val_ranges_.back();
     vals_.resize(num_vals); // No need to clear the `vals_`!
-    par::static_for_each(handles, [&](auto const& handle) {
+    par::for_each(handles, [&](auto const& handle) {
       auto const index = static_cast<size_t>(index_of(handle));
       TIT_ASSERT(index < count, "Index of the value is out of expected range!");
       auto const addr = par::fetch_and_add(val_ranges_[index], 1);

--- a/source/tit/geom/grid.hpp
+++ b/source/tit/geom/grid.hpp
@@ -105,15 +105,8 @@ private:
     // Pack the points into a multivector.
     cell_points_.assemble_tall(
         total_num_cells,
-        std::views::enumerate(points_),
-        [this](auto index_and_point) {
-          auto const& [_, point] = index_and_point;
-          return _point_to_cell_index(point);
-        },
-        [](auto index_and_point) {
-          auto const& [point_index, _] = index_and_point;
-          return point_index;
-        });
+        std::views::iota(size_t{0}, points_.size()),
+        [this](size_t index) { return _point_to_cell_index(points_[index]); });
   }
 
 public:

--- a/source/tit/sph/fluid_equations.hpp
+++ b/source/tit/sph/fluid_equations.hpp
@@ -61,7 +61,7 @@ public:
   constexpr void init(ParticleArray& particles) const {
     TIT_PROFILE_SECTION("tit::FluidEquations::init()");
     using PV = ParticleView<ParticleArray>;
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       // Initialize particle pressure (and sound speed).
       eos_.compute_pressure(a);
       // Initialize particle artificial viscosity switch value.
@@ -172,7 +172,7 @@ public:
     TIT_PROFILE_SECTION("tit::FluidEquations::compute_density()");
     using PV = ParticleView<ParticleArray>;
     // Clean density-related fields.
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Density fields.
       if constexpr (has<PV>(drho_dt)) drho_dt[a] = {};
       if constexpr (has<PV>(grad_rho)) grad_rho[a] = {};
@@ -208,7 +208,7 @@ public:
       }
     });
     // Renormalize fields.
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       // Do not renormalize fixed particles.
       if (fixed[a]) return;
       /// Renormalize density (if possible).
@@ -249,7 +249,7 @@ public:
     TIT_PROFILE_SECTION("tit::FluidEquations::compute_forces()");
     using PV = ParticleView<ParticleArray>;
     // Prepare velocity-related fields.
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Compute pressure (and sound speed).
       eos_.compute_pressure(a);
       /// Clean velocity-related fields.
@@ -330,7 +330,7 @@ public:
       }
 #endif
     });
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       if (fixed[a]) return;
 #if WITH_GRAVITY
       // TODO: Gravity.

--- a/source/tit/sph/fsi.hpp
+++ b/source/tit/sph/fsi.hpp
@@ -120,7 +120,7 @@ public:
     using PV = ParticleView<ParticleArray>;
     adjacent_particles.build([&](PV a) { return kernel_.radius(a); });
     // Store the reference state.
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Store initial particle positions.
       r_0[a] = r[a];
       /// Clean the renormalization matrix.
@@ -136,7 +136,7 @@ public:
       auto const L_flux = outer(r_0[b, a], grad0_W_ab);
       L[a] += V0_b * L_flux, L[b] += V0_a * L_flux;
     });
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Finalize kernel gradient renormalization matrix.
       auto const fact = lu(L[a]);
       if (fact) L[a] = transpose(fact->inverse());
@@ -164,7 +164,7 @@ public:
                                 ParticleAdjacency& adjacent_particles) const {
     using PV = ParticleView<ParticleArray>;
     // Prepare velocity-related fields.
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Clean velocity-related fields.
       dv_dt[a] = {};
       P[a] = {};
@@ -185,7 +185,7 @@ public:
       auto const v_flux = Pi_ab * grad0_W_ab;
       dv_dt[a] += m[b] * v_flux, dv_dt[b] -= m[a] * v_flux;
     });
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Finalize tensor of deformation gradient (stored in `P`)
       /// and compute auxiliary tensors from it.
       auto const F_a = P[a] * L[a];
@@ -214,7 +214,7 @@ public:
       auto const v_flux = (P[a] + P[b]) * grad0_W_ab;
       dv_dt[a] += m[b] * v_flux, dv_dt[b] -= m[a] * v_flux;
     });
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       if (fixed[a]) return;
 #if WITH_GRAVITY
       // TODO: Gravity.

--- a/source/tit/sph/gas_equations.hpp
+++ b/source/tit/sph/gas_equations.hpp
@@ -64,7 +64,7 @@ public:
     requires (has<ParticleArray>(required_fields))
   constexpr void init(ParticleArray& particles) const {
     using PV = ParticleView<ParticleArray>;
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       // Initialize particle pressure (and sound speed).
       eos_.compute_pressure(a);
       // Initialize particle width and Omega.
@@ -210,7 +210,7 @@ public:
       });
     }
     // Compute renormalization fields.
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Clean renormalization fields.
       if constexpr (has<PV>(S)) S[a] = {};
       if constexpr (has<PV>(L)) L[a] = {};
@@ -250,7 +250,7 @@ public:
                                 ParticleAdjacency& adjacent_particles) const {
     using PV = ParticleView<ParticleArray>;
     // Compute velocity derivative fields.
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       /// Compute pressure (and sound speed).
       eos_.compute_pressure(a);
       /// Clean velocity derivative fields.
@@ -317,7 +317,7 @@ public:
         du_dt[b] += m[a] * (dot(v_flux_b, v[b, a]) - Lambda_flux);
       }
     });
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       if (fixed[a]) return;
       /// Compute artificial viscosity switch time.
       if constexpr (has<PV>(dalpha_dt)) artvisc_.compute_switch_deriv(a);

--- a/source/tit/sph/time_integrator.hpp
+++ b/source/tit/sph/time_integrator.hpp
@@ -56,14 +56,14 @@ public:
     // Integrate particle density.
     equations_.compute_density(particles, adjacent_particles);
     if constexpr (has<PV>(drho_dt)) {
-      par::static_for_each(particles.views(), [&](PV a) {
+      par::for_each(particles.views(), [&](PV a) {
         if (fixed[a]) return;
         rho[a] += dt * drho_dt[a];
       });
     }
     // Integrate particle velocty (internal enegry, and rest).
     equations_.compute_forces(particles, adjacent_particles);
-    par::static_for_each(particles.views(), [&](PV a) {
+    par::for_each(particles.views(), [&](PV a) {
       if (fixed[a]) return;
       // Velocity is updated first, so the integrator is semi-implicit.
       v[a] += dt * dv_dt[a];


### PR DESCRIPTION
Some performance fixes are needed after we've upgrade to GCC 14.

It looks like the main source of the issue were `[[assume(...)]]` statements generated by checks. Those are replaced with `static_cast<void>(...)`.

Also, `par::static_for_each` was replaced with `par::for_each` in most of the places, where no deterministic behavior. Benchmarking with Clang shows that `par::for_each` is generally much faster, and there is no singnificant difference with GCC.

Also a single usage of `std::views::enumerate` was eleminated, since it is not supported by Clang.

Before:
```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
    150.87396        100.00000            1    main
    141.35065         93.68791        34130    tit::EulerIntegrator::step()
     60.30323         39.96928         3413    tit::ParticleAdjacency::build()
     42.36300         28.07840        34130    tit::FluidEquations::compute_density()
     21.31564         14.12811        34130    tit::FluidEquations::compute_forces()
     14.97319          9.92431        34130    tit::FluidEquations::setup_boundary()
      5.41447          3.58874         3413    tit::Grid::Grid() <--- 5x slower than GCC 13!
      3.24709          2.15219         3413    tit::ZCurveOrdering::ZCurveOrdering()
      0.00015          0.00010            1    tit::FluidEquations::init()
--------------------------------------------------------------------------------
```

```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
    140.08076        100.00000            1    main
    130.46606         93.13631        34130    tit::EulerIntegrator::step()
     53.92980         38.49908         3413    tit::ParticleAdjacency::build()
     39.61394         28.27936        34130    tit::FluidEquations::compute_density()
     18.82941         13.44182        34130    tit::FluidEquations::compute_forces()
     15.79793         11.27773        34130    tit::FluidEquations::setup_boundary()
      3.13533          2.23823         3413    tit::ZCurveOrdering::ZCurveOrdering()
      0.93483          0.66735         3413    tit::Grid::Grid()
      0.00019          0.00014            1    tit::FluidEquations::init()
--------------------------------------------------------------------------------
```