### PR TITLE
Restore SIMD support with Highway.

### DIFF
--- a/source/tit/core/CMakeLists.txt
+++ b/source/tit/core/CMakeLists.txt
@@ -27,6 +27,11 @@ add_tit_library(
     "multivector.hpp"
     "profiler.cpp"
     "profiler.hpp"
+    "simd.hpp"
+    "simd/mask.hpp"
+    "simd/reg.hpp"
+    "simd/reg_mask.hpp"
+    "simd/traits.hpp"
     "system.cpp"
     "system.hpp"
     "time.hpp"
@@ -37,7 +42,8 @@ add_tit_library(
     "vec/vec.hpp"
     "vec/vec_mask.hpp"
   DEPENDS
-    tit::base)
+    tit::base
+    hwy::hwy)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -54,6 +60,9 @@ add_tit_executable(
     "math.test.cpp"
     "meta.test.cpp"
     "mdvector.test.cpp"
+    "simd/mask.test.cpp"
+    "simd/reg.test.cpp"
+    "simd/reg_mask.test.cpp"
     "system.test.cpp"
     "time.test.cpp"
     "uint_utils.test.cpp"

--- a/source/tit/core/simd.hpp
+++ b/source/tit/core/simd.hpp
@@ -1,0 +1,13 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+// IWYU pragma: begin_exports
+#include "tit/core/simd/mask.hpp"
+#include "tit/core/simd/reg.hpp"
+#include "tit/core/simd/reg_mask.hpp"
+#include "tit/core/simd/traits.hpp"
+// IWYU pragma: end_exports

--- a/source/tit/core/simd/mask.hpp
+++ b/source/tit/core/simd/mask.hpp
@@ -1,0 +1,80 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <concepts>
+#include <type_traits>
+
+#include "tit/core/basic_types.hpp"
+#include "tit/core/simd/traits.hpp"
+
+namespace tit::simd {
+
+namespace impl {
+
+template<supported_type Num>
+struct mask_bits;
+
+template<std::integral Int>
+struct mask_bits<Int> : std::make_unsigned<Int> {};
+
+template<>
+struct mask_bits<float32_t> : std::type_identity<uint32_t> {};
+
+template<>
+struct mask_bits<float64_t> : std::type_identity<uint64_t> {};
+
+template<supported_type Num>
+using mask_bits_t = typename impl::mask_bits<Num>::type;
+
+} // namespace impl
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Scalar mask.
+template<supported_type Num>
+class Mask final {
+public:
+
+  /// Construct a mask equivalent to boolean @p b.
+  constexpr Mask(bool b = false) noexcept : bits_{b ? ~Bits{0} : Bits{0}} {}
+
+  /// Cast back to the boolean.
+  constexpr operator bool() const noexcept {
+    return bits_ != 0;
+  }
+
+  /// Mask negation operation.
+  friend constexpr auto operator!(Mask m) noexcept -> Mask {
+    return Mask{~m.bits_};
+  }
+
+  /// Mask conjunction operation.
+  friend constexpr auto operator&&(Mask m, Mask n) noexcept -> Mask {
+    return Mask{m.bits_ & n.bits_};
+  }
+
+  /// Mask disjunction operation.
+  friend constexpr auto operator||(Mask m, Mask n) noexcept -> Mask {
+    return Mask{m.bits_ | n.bits_};
+  }
+
+  /// Mask equality operation.
+  constexpr auto operator==(Mask const&) const noexcept -> bool = default;
+
+private:
+
+  using Bits = impl::mask_bits_t<Num>;
+
+  constexpr explicit Mask(Bits bits) noexcept : bits_{bits} {}
+
+  Bits bits_;
+
+}; // class Mask
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace tit::simd

--- a/source/tit/core/simd/mask.test.cpp
+++ b/source/tit/core/simd/mask.test.cpp
@@ -1,0 +1,53 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include "tit/core/simd.hpp"
+
+#include "tit/testing/test.hpp"
+
+namespace tit {
+namespace {
+
+using FloatMask = simd::Mask<float>;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Mask") {
+  static_assert(sizeof(FloatMask) == sizeof(float));
+  SUBCASE("zero initialization") {
+    FloatMask const m{};
+    CHECK_FALSE(m);
+  }
+  SUBCASE("value initialization") {
+    FloatMask const m{true};
+    CHECK(m);
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Mask::operator!") {
+  CHECK(!FloatMask{false});
+  CHECK_FALSE(!FloatMask{true});
+}
+
+TEST_CASE("simd::Mask::operator&&") {
+  CHECK_FALSE((FloatMask{false} && FloatMask{false}));
+  CHECK_FALSE((FloatMask{false} && FloatMask{true}));
+  CHECK_FALSE((FloatMask{true} && FloatMask{false}));
+  CHECK((FloatMask{true} && FloatMask{true}));
+}
+
+TEST_CASE("simd::Mask::operator||") {
+  CHECK_FALSE((FloatMask{false} || FloatMask{false}));
+  CHECK((FloatMask{false} || FloatMask{true}));
+  CHECK((FloatMask{true} || FloatMask{false}));
+  CHECK((FloatMask{true} || FloatMask{true}));
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace
+} // namespace tit

--- a/source/tit/core/simd/reg.hpp
+++ b/source/tit/core/simd/reg.hpp
@@ -1,0 +1,279 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <span>
+
+#include <hwy/highway.h>
+
+#include "tit/core/basic_types.hpp"
+#include "tit/core/checks.hpp"
+#include "tit/core/simd/reg_mask.hpp"
+#include "tit/core/simd/traits.hpp"
+
+namespace tit::simd {
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// SIMD register.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+class alignas(sizeof(Num) * Size) Reg final {
+public:
+
+  /// Highway tag type.
+  using Tag = hn::FixedTag<impl::fixed_width_type_t<Num>, Size>;
+
+  /// Highway register type.
+  using Base = hn::Vec<Tag>;
+
+  /// Associated mask register type.
+  using RegMask = tit::simd::RegMask<Num, Size>;
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// Base Highway register.
+  Base base; // NOLINT(*-non-private-member-variables-in-classes)
+
+  /// Construct SIMD register from the Highway register.
+  [[gnu::always_inline]]
+  Reg(Base const& b) noexcept
+      : base{b} {}
+
+  /// Fill-initialize the SIMD register with zeroes.
+  [[gnu::always_inline]]
+  Reg() noexcept
+      : base{hn::Zero(Tag{})} {}
+
+  /// Fill-initialize the SIMD register.
+  [[gnu::always_inline]]
+  explicit Reg(Num q) noexcept
+      : base{hn::Set(Tag{}, q)} {}
+
+  /// Load SIMD register from memory.
+  [[gnu::always_inline]]
+  explicit Reg(std::span<Num const> span) noexcept {
+    TIT_ASSERT(span.size() >= Size, "Span size is too small!");
+    base = hn::Load(Tag{}, span.data()); // NOLINT(*-prefer-member-initializer)
+  }
+
+  /// Store SIMD register into memory.
+  [[gnu::always_inline]]
+  void store(std::span<Num> span) const noexcept {
+    TIT_ASSERT(span.size() >= Size, "Span size is too small!");
+    hn::StoreU(base, Tag{}, span.data());
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// SIMD unary plus operation.
+  [[gnu::always_inline]]
+  friend auto operator+(Reg const& a) noexcept -> Reg const& {
+    return a;
+  }
+
+  /// SIMD addition operation.
+  [[gnu::always_inline]]
+  friend auto operator+(Reg const& a, Reg const& b) noexcept -> Reg {
+    return a.base + b.base;
+  }
+
+  /// SIMD addition with assignment operation.
+  [[gnu::always_inline]]
+  friend auto operator+=(Reg& a, Reg const& b) noexcept -> Reg& {
+    return a = a + b;
+  }
+
+  /// SIMD negation operation.
+  [[gnu::always_inline]]
+  friend auto operator-(Reg const& a) noexcept -> Reg {
+    return hn::Neg(a.base);
+  }
+
+  /// SIMD subtraction operation.
+  [[gnu::always_inline]]
+  friend auto operator-(Reg const& a, Reg const& b) noexcept -> Reg {
+    return a.base - b.base;
+  }
+
+  /// SIMD subtraction with assignment operation.
+  [[gnu::always_inline]]
+  friend auto operator-=(Reg& a, Reg const& b) noexcept -> Reg& {
+    return a = a - b;
+  }
+
+  /// SIMD multiplication operation.
+  [[gnu::always_inline]]
+  friend auto operator*(Reg const& a, Reg const& b) noexcept -> Reg {
+    return a.base * b.base;
+  }
+
+  /// SIMD multiplication with assignment operation.
+  [[gnu::always_inline]]
+  friend auto operator*=(Reg& a, Reg const& b) noexcept -> Reg& {
+    return a = a * b;
+  }
+
+  /// SIMD division operation.
+  [[gnu::always_inline]]
+  friend auto operator/(Reg const& a, Reg const& b) noexcept -> Reg {
+    return a.base / b.base;
+  }
+
+  /// SIMD division with assignment operation.
+  [[gnu::always_inline]]
+  friend auto operator/=(Reg& a, Reg const& b) noexcept -> Reg& {
+    return a = a / b;
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// SIMD "equal to" comparison operation.
+  [[gnu::always_inline]]
+  friend auto operator==(Reg const& a, Reg const& b) noexcept -> RegMask {
+    return a.base == b.base;
+  }
+
+  /// SIMD "not equal to" comparison operation.
+  [[gnu::always_inline]]
+  friend auto operator!=(Reg const& a, Reg const& b) noexcept -> RegMask {
+    return a.base != b.base;
+  }
+
+  /// SIMD "less than" comparison operation.
+  [[gnu::always_inline]]
+  friend auto operator<(Reg const& a, Reg const& b) noexcept -> RegMask {
+    return a.base < b.base;
+  }
+
+  /// SIMD "less than or equal to" comparison operation.
+  [[gnu::always_inline]]
+  friend auto operator<=(Reg const& a, Reg const& b) noexcept -> RegMask {
+    return a.base <= b.base;
+  }
+
+  /// SIMD "greater than" comparison operation.
+  [[gnu::always_inline]]
+  friend auto operator>(Reg const& a, Reg const& b) noexcept -> RegMask {
+    return a.base > b.base;
+  }
+
+  /// SIMD "greater than or equal to" comparison operation.
+  [[gnu::always_inline]]
+  friend auto operator>=(Reg const& a, Reg const& b) noexcept -> RegMask {
+    return a.base >= b.base;
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+}; // class Reg
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// SIMD element-wise minimum algorithm.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto min(Reg<Num, Size> const& a,
+                Reg<Num, Size> const& b) noexcept -> Reg<Num, Size> {
+  return hn::Min(a.base, b.base);
+}
+
+/// SIMD element-wise maximum algorithm.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto max(Reg<Num, Size> const& a,
+                Reg<Num, Size> const& b) noexcept -> Reg<Num, Size> {
+  return hn::Max(a.base, b.base);
+}
+
+/// SIMD element-wise filter algorithm.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto filter(RegMask<Num, Size> const& m,
+                   Reg<Num, Size> const& a) noexcept -> Reg<Num, Size> {
+  return hn::IfThenElseZero(m.base, a.base);
+}
+
+/// SIMD element-wise select algorithm.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto select(RegMask<Num, Size> const& m,
+                   Reg<Num, Size> const& a,
+                   Reg<Num, Size> const& b) noexcept -> Reg<Num, Size> {
+  return hn::IfThenElse(m.base, a.base, b.base);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// SIMD `floor` function overload.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto floor(Reg<Num, Size> const& a) noexcept -> Reg<Num, Size> {
+  return hn::Floor(a.base);
+}
+
+/// SIMD `round` function overload.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto round(Reg<Num, Size> const& a) noexcept -> Reg<Num, Size> {
+  return hn::Round(a.base);
+}
+
+/// SIMD `ceil` function overload.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto ceil(Reg<Num, Size> const& a) noexcept -> Reg<Num, Size> {
+  return hn::Ceil(a.base);
+}
+
+/// SIMD fused multiply-add operation.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto fma(Reg<Num, Size> const& a,
+                Reg<Num, Size> const& b,
+                Reg<Num, Size> const& c) noexcept -> Reg<Num, Size> {
+  return hn::MulAdd(a.base, b.base, c.base);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// SIMD horizontal sum reduction.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto sum(Reg<Num, Size> const& a) noexcept -> Num {
+  return hn::GetLane(hn::SumOfLanes(typename Reg<Num, Size>::Tag{}, a.base));
+}
+
+/// SIMD horizontal minimum reduction.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto min_value(Reg<Num, Size> const& a) noexcept -> Num {
+  return hn::GetLane(hn::MinOfLanes(typename Reg<Num, Size>::Tag{}, a.base));
+}
+
+/// SIMD horizontal maximum reduction.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto max_value(Reg<Num, Size> const& a) noexcept -> Num {
+  return hn::GetLane(hn::MaxOfLanes(typename Reg<Num, Size>::Tag{}, a.base));
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace tit::simd

--- a/source/tit/core/simd/reg.test.cpp
+++ b/source/tit/core/simd/reg.test.cpp
@@ -1,0 +1,269 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include <array>
+
+#include "tit/core/simd.hpp"
+
+#include "tit/testing/test.hpp"
+
+namespace tit {
+namespace {
+
+// 128-bit floating point SIMD appears to be supported on all platforms.
+using FloatArray = std::array<float, 4>;
+using FloatReg = simd::Reg<float, 4>;
+using FloatMask = simd::Mask<float>;
+using FloatMaskArray = std::array<FloatMask, 4>;
+using FloatRegMask = simd::RegMask<float, 4>;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Reg") {
+  SUBCASE("load and store") {
+    FloatArray const in{1.0F, 2.0F, 3.0F, 4.0F};
+    FloatReg const r(in);
+    FloatArray out{};
+    r.store(out);
+    CHECK(in == out);
+  }
+  SUBCASE("zero initialization") {
+    FloatReg const r{};
+    FloatArray out{1.0F};
+    r.store(out);
+    for (auto const& x : out) CHECK(x == 0.0F);
+  }
+  SUBCASE("value initialization") {
+    auto const val = 1.3F;
+    FloatReg const r(val);
+    FloatArray out{};
+    r.store(out);
+    for (auto const& x : out) CHECK(x == val);
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Reg::min") {
+  FloatArray const a{5.0F, 6.0F, 7.0F, 8.0F};
+  FloatArray const b{1.0F, 7.0F, 4.0F, 9.0F};
+  FloatReg const r = simd::min(FloatReg(a), FloatReg(b));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{1.0F, 6.0F, 4.0F, 8.0F});
+}
+
+TEST_CASE("simd::Reg::max") {
+  FloatArray const a{5.0F, 6.0F, 7.0F, 8.0F};
+  FloatArray const b{1.0F, 7.0F, 4.0F, 9.0F};
+  FloatReg const r = simd::max(FloatReg(a), FloatReg(b));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{5.0F, 7.0F, 7.0F, 9.0F});
+}
+
+TEST_CASE("simd::Reg::filter") {
+  FloatArray const a{5.0F, 6.0F, 7.0F, 8.0F};
+  FloatMaskArray const mask{true, false, true, false};
+  FloatReg const r = simd::filter(FloatRegMask(mask), FloatReg(a));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{5.0F, 0.0F, 7.0F, 0.0F});
+}
+
+TEST_CASE("simd::Reg::select") {
+  FloatArray const a{5.0F, 6.0F, 7.0F, 8.0F};
+  FloatArray const b{1.0F, 2.0F, 3.0F, 4.0F};
+  FloatMaskArray const mask{true, false, true, false};
+  FloatReg const r = simd::select(FloatRegMask(mask), FloatReg(a), FloatReg(b));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{5.0F, 2.0F, 7.0F, 4.0F});
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Reg::operator+") {
+  FloatArray const a{1.0F, 2.0F, 3.0F, 4.0F};
+  FloatArray const b{5.0F, 6.0F, 7.0F, 8.0F};
+  FloatArray const sum{6.0F, 8.0F, 10.0F, 12.0F};
+  SUBCASE("normal") {
+    FloatReg const r = FloatReg(a) + FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == sum);
+  }
+  SUBCASE("with assignment") {
+    FloatReg r(a);
+    r += FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == sum);
+  }
+}
+
+TEST_CASE("simd::Reg::operator-") {
+  FloatArray const b{1.0F, 2.0F, 3.0F, 4.0F};
+  SUBCASE("negation") {
+    FloatReg const r = -FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == FloatArray{-1.0F, -2.0F, -3.0F, -4.0F});
+  }
+  FloatArray const a{5.0F, 6.0F, 7.0F, 8.0F};
+  FloatArray const diff{4.0F, 4.0F, 4.0F, 4.0F};
+  SUBCASE("normal") {
+    FloatReg const r = FloatReg(a) - FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == diff);
+  }
+  SUBCASE("with assignment") {
+    FloatReg r(a);
+    r -= FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == diff);
+  }
+}
+
+TEST_CASE("simd::Reg::operator*") {
+  FloatArray const a{2.0F, 3.0F, 4.0F, 5.0F};
+  FloatArray const b{6.0F, 7.0F, 8.0F, 9.0F};
+  FloatArray const prod{12.0F, 21.0F, 32.0F, 45.0F};
+  SUBCASE("normal") {
+    FloatReg const r = FloatReg(a) * FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == prod);
+  }
+  SUBCASE("with assignment") {
+    FloatReg r(a);
+    r *= FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == prod);
+  }
+}
+
+TEST_CASE("simd::Reg::operator/") {
+  FloatArray const a{12.0F, 21.0F, 32.0F, 45.0F};
+  FloatArray const b{6.0F, 7.0F, 8.0F, 9.0F};
+  FloatArray const quot{2.0F, 3.0F, 4.0F, 5.0F};
+  SUBCASE("normal") {
+    FloatReg const r = FloatReg(a) / FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == quot);
+  }
+  SUBCASE("with assignment") {
+    FloatReg r(a);
+    r /= FloatReg(b);
+    FloatArray out{};
+    r.store(out);
+    CHECK(out == quot);
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Reg::floor") {
+  FloatArray const a{1.5F, 2.7F, 3.1F, 4.9F};
+  FloatReg const r = simd::floor(FloatReg(a));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{1.0F, 2.0F, 3.0F, 4.0F});
+}
+
+TEST_CASE("simd::Reg::round") {
+  FloatArray const a{1.5F, 2.7F, 3.1F, 4.9F};
+  FloatReg const r = simd::round(FloatReg(a));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{2.0F, 3.0F, 3.0F, 5.0F});
+}
+
+TEST_CASE("simd::Reg::ceil") {
+  FloatArray const a{1.5F, 2.7F, 3.1F, 4.9F};
+  FloatReg const r = simd::ceil(FloatReg(a));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{2.0F, 3.0F, 4.0F, 5.0F});
+}
+
+TEST_CASE("simd::Reg::fma") {
+  FloatArray const a{1.0F, 2.0F, 3.0F, 4.0F};
+  FloatArray const b{5.0F, 6.0F, 7.0F, 8.0F};
+  FloatArray const c{9.0F, 10.0F, 11.0F, 12.0F};
+  FloatReg const r = simd::fma(FloatReg(a), FloatReg(b), FloatReg(c));
+  FloatArray out{};
+  r.store(out);
+  CHECK(out == FloatArray{14.0F, 22.0F, 32.0F, 44.0F});
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Reg::operator<=>") {
+  FloatArray const a{1.0F, 2.0F, 4.0F, 4.0F};
+  FloatArray const b{1.0F, 5.0F, 3.0F, 7.0F};
+  SUBCASE("==") {
+    auto const m = FloatReg(a) == FloatReg(b);
+    FloatMaskArray out{};
+    m.store(out);
+    CHECK(out == FloatMaskArray{true, false, false, false});
+  }
+  SUBCASE("!=") {
+    auto const m = FloatReg(a) != FloatReg(b);
+    FloatMaskArray out{};
+    m.store(out);
+    CHECK(out == FloatMaskArray{false, true, true, true});
+  }
+  SUBCASE("<") {
+    auto const m = FloatReg(a) < FloatReg(b);
+    FloatMaskArray out{};
+    m.store(out);
+    CHECK(out == FloatMaskArray{false, true, false, true});
+  }
+  SUBCASE("<=") {
+    auto const m = FloatReg(a) <= FloatReg(b);
+    FloatMaskArray out{};
+    m.store(out);
+    CHECK(out == FloatMaskArray{true, true, false, true});
+  }
+  SUBCASE(">") {
+    auto const m = FloatReg(a) > FloatReg(b);
+    FloatMaskArray out{};
+    m.store(out);
+    CHECK(out == FloatMaskArray{false, false, true, false});
+  }
+  SUBCASE(">=") {
+    auto const m = FloatReg(a) >= FloatReg(b);
+    FloatMaskArray out{};
+    m.store(out);
+    CHECK(out == FloatMaskArray{true, false, true, false});
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::Reg::sum") {
+  FloatArray const a{1.0F, 2.0F, 3.0F, 4.0F};
+  CHECK(simd::sum(FloatReg(a)) == 10.0F);
+}
+
+TEST_CASE("simd::Reg::min_value") {
+  FloatArray const a{3.0F, 2.0F, 4.0F, 1.0F};
+  CHECK(simd::min_value(FloatReg(a)) == 1.0F);
+}
+
+TEST_CASE("simd::Reg::max_value") {
+  FloatArray const a{3.0F, 2.0F, 4.0F, 1.0F};
+  CHECK(simd::max_value(FloatReg(a)) == 4.0F);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace
+} // namespace tit

--- a/source/tit/core/simd/reg_mask.hpp
+++ b/source/tit/core/simd/reg_mask.hpp
@@ -1,0 +1,96 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <span>
+
+#include <hwy/highway.h>
+
+#include "tit/core/basic_types.hpp"
+#include "tit/core/checks.hpp"
+#include "tit/core/simd/mask.hpp"
+#include "tit/core/simd/traits.hpp"
+
+namespace tit::simd {
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// SIMD register mask.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+class alignas(sizeof(Num) * Size) RegMask final {
+public:
+
+  /// Highway tag type.
+  using Tag = hn::FixedTag<impl::fixed_width_type_t<Num>, Size>;
+
+  /// Highway mask register type.
+  using Base = hn::Mask<Tag>;
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  /// Base Highway register.
+  Base base; // NOLINT(*-non-private-member-variables-in-classes)
+
+  /// Construct SIMD register mask from the Highway register.
+  [[gnu::always_inline]]
+  RegMask(Base const& b) noexcept
+      : base{b} {}
+
+  /// Fill-initialize the SIMD register mask with zeroes.
+  [[gnu::always_inline]]
+  RegMask() noexcept
+      : base{hn::MaskFromVec(hn::Zero(Tag{}))} {}
+
+  /// Fill-initialize the SIMD register mask.
+  [[gnu::always_inline]]
+  explicit RegMask(Mask<Num> q) noexcept
+      : base{hn::MaskFromVec(hn::Set(Tag{}, std::bit_cast<Num>(q)))} {}
+
+  /// Load SIMD register mask from memory.
+  [[gnu::always_inline]]
+  explicit RegMask(std::span<Mask<Num> const> span) noexcept {
+    TIT_ASSERT(span.size() >= Size, "Span size is too small!");
+    base = hn::MaskFromVec( // NOLINT(*-prefer-member-initializer)
+        hn::Load(Tag{}, std::bit_cast<Num const*>(span.data())));
+  }
+
+  /// Store SIMD register mask into memory.
+  [[gnu::always_inline]]
+  void store(std::span<Mask<Num>> span) const noexcept {
+    TIT_ASSERT(span.size() >= Size, "Span size is too small!");
+    hn::StoreU(hn::VecFromMask(Tag{}, base),
+               Tag{},
+               std::bit_cast<Num*>(span.data()));
+  }
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+}; // class RegMask
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Check if any SIMD register mask element is set to true.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto any(RegMask<Num, Size> const& m) noexcept -> bool {
+  return !hn::AllFalse(typename RegMask<Num, Size>::Tag{}, m.base);
+}
+
+/// Check if all SIMD register mask elements are set to true.
+template<class Num, size_t Size>
+  requires supported<Num, Size>
+[[gnu::always_inline]]
+inline auto all(RegMask<Num, Size> const& m) noexcept -> bool {
+  return hn::AllTrue(typename RegMask<Num, Size>::Tag{}, m.base);
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace tit::simd

--- a/source/tit/core/simd/reg_mask.test.cpp
+++ b/source/tit/core/simd/reg_mask.test.cpp
@@ -1,0 +1,70 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include <array>
+
+#include "tit/core/simd.hpp"
+
+#include "tit/testing/test.hpp"
+
+namespace tit {
+namespace {
+
+// 128-bit floating point SIMD appears to be supported on all platforms.
+using FloatMask = simd::Mask<float>;
+using FloatMaskArray = std::array<FloatMask, 4>;
+using FloatRegMask = simd::RegMask<float, 4>;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::RegMask") {
+  SUBCASE("load and store") {
+    FloatMaskArray const in{false, true, true, false};
+    FloatRegMask const r(in);
+    FloatMaskArray out{};
+    r.store(out);
+    CHECK(in == out);
+  }
+  SUBCASE("zero initialization") {
+    FloatRegMask const r{};
+    FloatMaskArray out{true};
+    r.store(out);
+    for (auto const& x : out) CHECK_FALSE(x);
+  }
+  SUBCASE("value initialization") {
+    FloatRegMask const r(true);
+    FloatMaskArray out{};
+    r.store(out);
+    for (auto const& x : out) CHECK(x);
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("simd::RegMask::any_and_all") {
+  SUBCASE("all") {
+    FloatMaskArray const a{true, true, true, true};
+    FloatRegMask const ra(a);
+    CHECK(any(ra));
+    CHECK(all(ra));
+  }
+  SUBCASE("some") {
+    FloatMaskArray const a{true, false, true, false};
+    FloatRegMask const ra(a);
+    CHECK(any(ra));
+    CHECK_FALSE(all(ra));
+  }
+  SUBCASE("none") {
+    FloatMaskArray const a{false, false, false, false};
+    FloatRegMask const ra(a);
+    CHECK_FALSE(any(ra));
+    CHECK_FALSE(all(ra));
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace
+} // namespace tit

--- a/source/tit/core/simd/traits.hpp
+++ b/source/tit/core/simd/traits.hpp
@@ -1,0 +1,126 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <bit>
+#include <concepts>
+#include <type_traits>
+
+#include "tit/core/basic_types.hpp"
+#include "tit/core/type_traits.hpp"
+
+namespace tit::simd {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Is SIMD supported for the specified numeric type?
+template<class Num>
+concept supported_type = std::integral<Num> || std::floating_point<Num>;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Minimal byte width of the SIMD register that is available on the current
+/// hardware.
+///
+/// That is 16 bytes for all supported instruction sets.
+inline constexpr size_t min_reg_byte_width_v{
+#ifdef __ARM_NEON
+    16
+#elifdef __SSE__
+    16
+#else
+    0
+#endif
+};
+
+/// Maximal byte width of the SIMD register that is available on the current
+/// hardware.
+///
+/// That is 16 bytes for NEON and SSE instruction set, 32 and 64 bytes for
+/// AVX and AVX-512 respectively.
+inline constexpr size_t max_reg_byte_width_v{
+#ifdef __ARM_NEON
+    16
+#elifdef __AVX512F__
+    64
+#elifdef __AVX__
+    32
+#elifdef __SSE__
+    16
+#else
+    0
+#endif
+};
+
+// Just in case.
+static_assert(max_reg_byte_width_v >= min_reg_byte_width_v &&
+              std::has_single_bit(max_reg_byte_width_v / min_reg_byte_width_v));
+
+/// Minimal SIMD register size for the specified type.
+template<supported_type Num>
+inline constexpr size_t min_reg_size_v = min_reg_byte_width_v / sizeof(Num);
+
+/// Maximal SIMD register size for the specified type.
+template<supported_type Num>
+inline constexpr size_t max_reg_size_v = max_reg_byte_width_v / sizeof(Num);
+
+/// Is SIMD supported for the specified numeric type and size?
+template<class Num, size_t Size>
+concept supported =
+    supported_type<Num> &&
+    in_range_v<Size, min_reg_size_v<Num>, max_reg_size_v<Num>> &&
+    (Size % min_reg_size_v<Num> == 0);
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+namespace impl {
+
+// In Highway, type is identified as an integer, if it is one of the standard
+// fixed-width types. This leads to the problem that if, for example, `int64_t`
+// is defined as `long long` on some platforms, the specialization for `long`
+// would be missing. Even if `long` and `long long` have the same size, they are
+// not the same type:
+//
+// static_assert(sizeof(long) == sizeof(long long) &&
+//               !std::same_as<long, long long>);
+//
+// So, we need to map the incoming integral types to the corresponding
+// standard fixed-width types, leaving other types as they are.
+
+template<supported_type Num>
+struct fixed_width_type;
+
+template<supported_type Num>
+using fixed_width_type_t = typename fixed_width_type<Num>::type;
+
+template<std::unsigned_integral UInt>
+  requires (sizeof(UInt) == 1)
+struct fixed_width_type<UInt> : std::type_identity<uint8_t> {};
+
+template<std::unsigned_integral UInt>
+  requires (sizeof(UInt) == 2)
+struct fixed_width_type<UInt> : std::type_identity<uint16_t> {};
+
+template<std::unsigned_integral UInt>
+  requires (sizeof(UInt) == 4)
+struct fixed_width_type<UInt> : std::type_identity<uint32_t> {};
+
+template<std::unsigned_integral UInt>
+  requires (sizeof(UInt) == 8)
+struct fixed_width_type<UInt> : std::type_identity<uint64_t> {};
+
+template<std::signed_integral SInt>
+struct fixed_width_type<SInt> :
+    std::make_signed<fixed_width_type_t<std::make_unsigned_t<SInt>>> {};
+
+template<std::floating_point Float>
+struct fixed_width_type<Float> : std::type_identity<Float> {};
+
+} // namespace impl
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace tit::simd


### PR DESCRIPTION
PR adds a wrapper around the Google Highway library that will be used in our vector class to restore vectorization.