### PR TITLE
Continue refactoring the SPH library.

### DIFF
--- a/source/tit/core/math.hpp
+++ b/source/tit/core/math.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <bit>
 #include <cmath>
 #include <concepts>
 #include <expected>
@@ -221,6 +222,20 @@ constexpr auto is_tiny(Num a) noexcept -> bool {
 template<class Num>
 constexpr auto approx_equal_to(Num a, Num b) -> bool {
   return is_tiny(a - b);
+}
+
+/// Check if two numbers are bitwise equal.
+///
+/// This function may be used to as a fast comparison of floating-point numbers
+/// that are known to be not NaN.
+template<std::floating_point Num>
+[[gnu::always_inline]]
+constexpr auto bitwise_equal(Num a, Num b) noexcept -> bool {
+  if constexpr (sizeof(Num) == sizeof(uint32_t)) {
+    return std::bit_cast<uint32_t>(a) == std::bit_cast<uint32_t>(b);
+  } else if constexpr (sizeof(Num) == sizeof(uint64_t)) {
+    return std::bit_cast<uint64_t>(a) == std::bit_cast<uint64_t>(b);
+  } else static_assert(false);
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/core/math.test.cpp
+++ b/source/tit/core/math.test.cpp
@@ -122,6 +122,17 @@ TEST_CASE_TEMPLATE("approx_equal_to", Num, NUM_TYPES) {
                               Num{1.23}));
 }
 
+TEST_CASE_TEMPLATE("bitwise_equal", Num, NUM_TYPES) {
+  // Check ordinary numbers.
+  CHECK(bitwise_equal(Num{1.23}, Num{1.23}));
+  CHECK_FALSE(bitwise_equal(Num{1.23}, Num{1.24}));
+  // NaNs are equal due to bitwise comparison.
+  CHECK(bitwise_equal(std::numeric_limits<Num>::quiet_NaN(),
+                      std::numeric_limits<Num>::quiet_NaN()));
+  // Zeros with different signs are not equal due to bitwise comparison.
+  CHECK_FALSE(bitwise_equal(Num{+0.0}, Num{-0.0}));
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 TEST_CASE_TEMPLATE("newton", Num, NUM_TYPES) {

--- a/source/tit/sph/equation_of_state.hpp
+++ b/source/tit/sph/equation_of_state.hpp
@@ -134,7 +134,7 @@ concept pressure_correction = std::same_as<PC, NoCorrection> || //
                               std::same_as<PC, HughesGrahamCorrection>;
 
 /// Tait equation equation of state (for weakly-compressible fluids).
-template<pressure_correction Correction = NoCorrection>
+template<pressure_correction Correction = HughesGrahamCorrection>
 class TaitEquationOfState final {
 public:
 
@@ -146,11 +146,11 @@ public:
 
   /// Construct an equation of state.
   ///
-  /// @param cs_0  Reference sound speed, typically 10x of the expected
-  ///              velocity.
-  /// @param rho_0 Reference density.
-  /// @param p_0   Background pressure.
-  /// @param gamma Polytropic index.
+  /// @param cs_0       Reference sound speed, typically 10x of the expected
+  ///                   velocity.
+  /// @param rho_0      Reference density.
+  /// @param p_0        Background pressure.
+  /// @param gamma      Polytropic index.
   /// @param correction Pressure correction method.
   constexpr explicit TaitEquationOfState(real_t cs_0,
                                          real_t rho_0,
@@ -190,7 +190,7 @@ private:
 }; // class TaitEquationOfState
 
 /// Linear Tait equation equation of state (for weakly-compressible fluids).
-template<pressure_correction Correction = NoCorrection>
+template<pressure_correction Correction = HughesGrahamCorrection>
 class LinearTaitEquationOfState final {
 public:
 
@@ -202,10 +202,11 @@ public:
 
   /// Construct an equation of state.
   ///
-  /// @param cs_0  Reference sound speed, typically 10x of the expected
-  ///              velocity.
-  /// @param rho_0 Reference density.
-  /// @param p_0   Background pressure.
+  /// @param cs_0       Reference sound speed, typically 10x of the expected
+  ///                   velocity.
+  /// @param rho_0      Reference density.
+  /// @param p_0        Background pressure.
+  /// @param correction Pressure correction method.
   constexpr LinearTaitEquationOfState(real_t cs_0,
                                       real_t rho_0,
                                       real_t p_0 = 0.0,

--- a/source/tit/sph/field.hpp
+++ b/source/tit/sph/field.hpp
@@ -57,9 +57,9 @@ public:
   }
 
   /// Field value delta for the specified particle view.
-  template<class Self, impl::has_field_<Self> PV>
-  constexpr auto operator[](this const Self& self, PV&& a, PV&& b) noexcept {
-    return std::forward<PV>(a)[self] - std::forward<PV>(b)[self];
+  template<class Self, impl::has_field_<Self> PVa, impl::has_field_<Self> PVb>
+  constexpr auto operator[](this const Self& self, PVa&& a, PVb&& b) noexcept {
+    return std::forward<PVa>(a)[self] - std::forward<PVb>(b)[self];
   }
 
   /// Average of the field values over the specified particle views.
@@ -222,11 +222,10 @@ namespace sph {
 /// Particle position.
 TIT_DEFINE_VECTOR_FIELD(r)
 } // namespace sph
+TIT_DEFINE_VECTOR_FIELD(dr)
 
 /// Particle velocity.
 TIT_DEFINE_VECTOR_FIELD(v)
-/// Particle velocity (XSPH model).
-TIT_DEFINE_VECTOR_FIELD(v_xsph)
 /// Particle acceleration.
 TIT_DEFINE_VECTOR_FIELD(dv_dt)
 /// Particle velocity gradient.
@@ -247,8 +246,6 @@ TIT_DEFINE_SCALAR_FIELD(drho_dt)
 
 /// Particle width.
 TIT_DEFINE_SCALAR_FIELD(h)
-/// Particle "Omega" variable (Grad-H model)
-TIT_DEFINE_SCALAR_FIELD(Omega)
 
 /// Particle pressure.
 TIT_DEFINE_SCALAR_FIELD(p)
@@ -271,10 +268,15 @@ TIT_DEFINE_SCALAR_FIELD(alpha)
 /// Particle artificial viscosity switch time derivative.
 TIT_DEFINE_SCALAR_FIELD(dalpha_dt)
 
-/// Kernel renormalization coefficient (Shepard filter).
-TIT_DEFINE_SCALAR_FIELD(S)
-/// Kernel gradient renormalization matrix.
+/// Particle concentration value.
+TIT_DEFINE_SCALAR_FIELD(C)
+/// Particle normal vector.
+TIT_DEFINE_VECTOR_FIELD(N)
+/// Particle renormalization matrix.
 TIT_DEFINE_MATRIX_FIELD(L)
+
+/// Particle free surface flag.
+TIT_DEFINE_SCALAR_FIELD(FS)
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/tit/sph/particle_array.hpp
+++ b/source/tit/sph/particle_array.hpp
@@ -40,7 +40,7 @@ class ParticleView final {
 public:
 
   /// Particle array type.
-  using Array = std::remove_cvref_t<ParticleArray>;
+  using Array = std::remove_const_t<ParticleArray>;
 
   /// Particle space.
   static constexpr space auto space = Array::space;
@@ -74,6 +74,16 @@ public:
   /// Check if the particle has the specified type.
   constexpr auto has_type(ParticleType type) const noexcept -> bool {
     return array().has_type(index(), type);
+  }
+
+  /// Check if the particle is fluid.
+  constexpr auto is_fluid() const noexcept -> bool {
+    return has_type(ParticleType::fluid);
+  }
+
+  /// Check if the particle is fixed.
+  constexpr auto is_fixed() const noexcept -> bool {
+    return has_type(ParticleType::fixed);
   }
 
   /// Particle field value.


### PR DESCRIPTION
Continue working on improvements in the SPH library (beginning is in #93).

- `S` was renamed to `C` (concentration).
- Fix a bug with computing field value differences when the the arguments have different CV qualifiers.
- Density gradients are now renormalized for all particles, and not only fluid.
- Particle Shifting Technique (PST) is implemented (and hardcoded).
- TVD Runge-Kutta 3 time integrator is now used by default.
- Hughes-Graham pressure-density correction is now enabled by default.

Still some things remain:

- Boundary conditions must split out from fluid equations.
- PST must not be mandatory.
- Time step calculation.

Time difference is huge due to the change in the time integrator and a huge increase of the time step.

- **Old test**:

```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
     72.75846        100.00000            1    main
     62.19032         85.47504        34130    EulerIntegrator::step()
     21.08634         28.98129        34130    FluidEquations::compute_density()
     15.90384         21.85840        34130    FluidEquations::setup_boundary()
     14.30144         19.65606         3413    ParticleMesh::update()
     11.89478         16.34831         3413    ParticleMesh::search()
     10.02683         13.78099        34130    FluidEquations::compute_forces()
      2.40631          3.30726         3413    ParticleMesh::partition()
      0.71438          0.98184         6826    RecursiveBisection::operator()
      0.45213          0.62141         3413    GridSearch::operator()
      0.00032          0.00044            1    FluidEquations::init()
--------------------------------------------------------------------------------
```

- **New test**:

```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
     44.51821        100.00000            1    main
     39.10848         87.84828         6901    RungeKuttaIntegrator::step()
     14.44302         32.44295        20703    FluidEquations::compute_density()
      9.96911         22.39334        20703    FluidEquations::setup_boundary()
      5.67632         12.75055        20703    FluidEquations::compute_forces()
      4.87205         10.94394         6901    FluidEquations::compute_shifts()
      2.99357          6.72438          691    ParticleMesh::update()
      2.46315          5.53291          691    ParticleMesh::search()
      0.53028          1.19115          691    ParticleMesh::partition()
      0.10936          0.24566          691    RecursiveBisection::operator()
      0.06656          0.14951          691    GridSearch::operator()
      0.03779          0.08489          691    GridGraphPartition::operator()
      0.00000          0.00000            1    FluidEquations::init()
--------------------------------------------------------------------------------
```
