### PR TITLE
Clean-up multivector implementation.

### DIFF
--- a/source/tit/core/CMakeLists.txt
+++ b/source/tit/core/CMakeLists.txt
@@ -93,6 +93,7 @@ add_tit_executable(
     "meta/set.test.cpp"
     "meta/type.test.cpp"
     "mdvector.test.cpp"
+    "multivector.test.cpp"
     "par/atomic.test.cpp"
     "par/control.test.cpp"
     "par/memory_pool.test.cpp"

--- a/source/tit/core/mdvector.hpp
+++ b/source/tit/core/mdvector.hpp
@@ -139,7 +139,7 @@ class Mdvector {
 public:
 
   /// Construct multidimensional vector.
-  Mdvector() noexcept = default;
+  constexpr Mdvector() noexcept = default;
 
   /// Construct multidimensional vector with specified size.
   template<class... Extents>

--- a/source/tit/core/multivector.test.cpp
+++ b/source/tit/core/multivector.test.cpp
@@ -1,0 +1,153 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include <algorithm>
+#include <ranges>
+#include <utility>
+#include <vector>
+
+#include "tit/core/basic_types.hpp"
+#include "tit/core/multivector.hpp"
+
+#include "tit/testing/test.hpp"
+
+namespace tit {
+namespace {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("Multivector") {
+  SUBCASE("empty") {
+    const Multivector<int> multivector{};
+    CHECK(multivector.size() == 0);
+    CHECK(multivector.empty());
+    CHECK(std::ranges::empty(multivector.bucket_sizes()));
+    CHECK(std::ranges::empty(multivector.buckets()));
+  }
+  SUBCASE("from initial values") {
+    const Multivector multivector{{1, 2, 3, 4}, {5, 6, 7}, {8, 9}};
+    CHECK(multivector.size() == 3);
+    CHECK_FALSE(multivector.empty());
+    CHECK(std::ranges::equal(multivector.bucket_sizes(), std::vector{4, 3, 2}));
+    CHECK(std::ranges::equal(multivector.buckets() | std::views::join,
+                             std::vector{1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    CHECK(std::ranges::equal(multivector[0], std::vector{1, 2, 3, 4}));
+    CHECK(std::ranges::equal(multivector[1], std::vector{5, 6, 7}));
+    CHECK(std::ranges::equal(multivector[2], std::vector{8, 9}));
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("Multivector::clear") {
+  Multivector multivector{{1, 2, 3, 4}, {5, 6, 7}, {8, 9}};
+  REQUIRE(multivector.size() == 3);
+  multivector.clear();
+  CHECK(multivector.empty());
+}
+
+TEST_CASE("Multivector::append_bucket") {
+  // Populate a multivector with buckets.
+  const std::vector<std::vector<int>> buckets{
+      {1, 2, 3, 4},
+      {5, 6, 7},
+      {8, 9},
+  };
+  Multivector<int> multivector{};
+  for (const auto& bucket : buckets) multivector.append_bucket(bucket);
+
+  // Ensure the multivector is correct.
+  REQUIRE(multivector.size() == buckets.size());
+  for (const auto& [bucket, expected] :
+       std::views::zip(multivector.buckets(), buckets)) {
+    CHECK(std::ranges::equal(bucket, expected));
+  }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("Multivector::assign_pairs_seq") {
+  // Build a multivector from sequence of pairs.
+  const std::vector<std::pair<size_t, int>> pairs{
+      {0, 1},
+      {0, 2},
+      {0, 3},
+      {0, 4},
+      {1, 5},
+      {1, 6},
+      {1, 7},
+      {2, 8},
+      {2, 9},
+  };
+  Multivector<int> multivector{};
+  multivector.assign_pairs_seq(3, pairs);
+
+  // Ensure the multivector is correct.
+  REQUIRE(multivector.size() == 3);
+  CHECK(std::ranges::equal(multivector[0], std::vector{1, 2, 3, 4}));
+  CHECK(std::ranges::equal(multivector[1], std::vector{5, 6, 7}));
+  CHECK(std::ranges::equal(multivector[2], std::vector{8, 9}));
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("Multivector::assign_pairs_par_tall") {
+  // Build a multivector from a sequence of pairs.
+  const std::vector<std::pair<size_t, int>> pairs{
+      {0, 1},
+      {2, 8},
+      {0, 2},
+      {0, 4},
+      {1, 5},
+      {1, 6},
+      {0, 3},
+      {1, 7},
+      {2, 9},
+  };
+  Multivector<int> multivector{};
+  multivector.assign_pairs_par_tall(3, pairs);
+
+  // Sort the buckets, since parallel algorithms does not guarantee order.
+  std::ranges::for_each(multivector.buckets(), std::ranges::sort);
+
+  // Ensure the multivector is correct.
+  REQUIRE(multivector.size() == 3);
+  CHECK(std::ranges::equal(multivector[0], std::vector{1, 2, 3, 4}));
+  CHECK(std::ranges::equal(multivector[1], std::vector{5, 6, 7}));
+  CHECK(std::ranges::equal(multivector[2], std::vector{8, 9}));
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TEST_CASE("Multivector::assign_pairs_par_wide") {
+  // Build a multivector from a sequence of pairs.
+  const std::vector<std::pair<size_t, int>> pairs{
+      {0, 1},
+      {2, 8},
+      {0, 2},
+      {0, 4},
+      {1, 5},
+      {1, 6},
+      {0, 3},
+      {1, 7},
+      {2, 9},
+  };
+  Multivector<int> multivector{};
+  multivector.assign_pairs_par_wide(3, pairs);
+
+  // Sort the buckets, since parallel algorithms does not guarantee order.
+  std::ranges::for_each(multivector.buckets(), std::ranges::sort);
+
+  // Ensure the multivector is correct.
+  REQUIRE(multivector.size() == 3);
+  CHECK(std::ranges::equal(multivector[0], std::vector{1, 2, 3, 4}));
+  CHECK(std::ranges::equal(multivector[1], std::vector{5, 6, 7}));
+  CHECK(std::ranges::equal(multivector[2], std::vector{8, 9}));
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace
+} // namespace tit

--- a/source/tit/geom/search/grid_search.hpp
+++ b/source/tit/geom/search/grid_search.hpp
@@ -16,6 +16,7 @@
 #include "tit/core/multivector.hpp"
 #include "tit/core/profiler.hpp"
 #include "tit/core/type_traits.hpp"
+#include "tit/core/utils.hpp"
 #include "tit/core/vec.hpp"
 
 #include "tit/geom/bbox.hpp"
@@ -57,12 +58,12 @@ public:
     cell_extents_recip_ = Vec(1) / cell_extents_;
 
     // Pack the points into a multivector.
-    cell_points_.assemble_tall( //
+    cell_points_.assign_pairs_par_tall(
         prod(num_cells_),
-        std::views::iota(size_t{0}, points_.size()),
-        [this](size_t index) {
-          return flat_cell_index_(cell_index_(points_[index]));
-        });
+        iota_perm(points_) | std::views::transform([this](size_t point) {
+          const auto cell = cell_index_(points_[point]);
+          return std::pair{flat_cell_index_(cell), point};
+        }));
 
     // NOLINTEND(*-prefer-member-initializer)
   }

--- a/source/tit/graph/graph.hpp
+++ b/source/tit/graph/graph.hpp
@@ -41,6 +41,25 @@ public:
            std::views::join;
   }
 
+  template<class Func>
+  constexpr auto transform_edges(Func fn) const noexcept {
+    return std::views::iota(0UZ, num_nodes()) |
+           std::views::transform([this, fn](size_t row_index) {
+             return (*this)[row_index] |
+                    // Take only lower part of the row.
+                    std::views::take_while([row_index](size_t col_index) {
+                      return col_index < row_index;
+                    }) |
+                    // Pack row and column indices into a tuple.
+                    std::views::transform([row_index](size_t col_index) {
+                      return std::tuple{col_index, row_index};
+                    }) |
+                    // Apply the transformation function.
+                    std::views::transform(fn);
+           }) |
+           std::views::join;
+  }
+
 }; // class Graph
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/sph/particle_mesh.hpp
+++ b/source/tit/sph/particle_mesh.hpp
@@ -160,7 +160,7 @@ private:
 
     // Compress the adjacency graph.
     adjacency_.clear();
-    for (const auto& x : adjacency) adjacency_.push_back(x);
+    for (const auto& x : adjacency) adjacency_.append_bucket(x);
 
     // Search for the interpolation points for the fixed particles.
     static std::vector<std::vector<size_t>> interp_adjacency{};
@@ -191,7 +191,7 @@ private:
 
     // Compress the interpolation graph.
     interp_adjacency_.clear();
-    for (const auto& x : interp_adjacency) interp_adjacency_.push_back(x);
+    for (const auto& x : interp_adjacency) interp_adjacency_.append_bucket(x);
   }
 
   template<particle_array ParticleArray>
@@ -252,16 +252,16 @@ private:
     }
 
     // Assemble the block adjacency graph.
-    block_edges_.assemble_wide( //
+    block_edges_.assign_pairs_par_wide(
         num_parts + 1,
-        adjacency_.edges(),
-        [parts](const auto& ab) {
-          const auto& [a, b] = ab;
-          return PartVec::common(parts[a], parts[b]);
-        });
+        adjacency_.transform_edges([parts](const auto& ab) {
+          const auto [a, b] = ab;
+          const auto part_ab = PartVec::common(parts[a], parts[b]);
+          return std::pair{part_ab, ab};
+        }));
 
     // Report the block sizes.
-    TIT_STATS("ParticleMesh::block_edges_", block_edges_.sizes());
+    TIT_STATS("ParticleMesh::block_edges_", block_edges_.bucket_sizes());
   }
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR refactors `Multivector` class and covers it with tests. Performance got slightly better (since sequential and parallel-tall construction from pairs does not require a shift).

- **Before**:

```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
     74.29317        100.00000            1    main
     64.67167         87.04928        34130    EulerIntegrator::step()
     20.83694         28.04691        34130    FluidEquations::compute_density()
     17.20549         23.15891         3413    ParticleMesh::update()
     15.88012         21.37494        34130    FluidEquations::setup_boundary()
     14.52390         19.54945         3413    ParticleMesh::search()
      9.88201         13.30137        34130    FluidEquations::compute_forces()
      2.68070          3.60827         3413    ParticleMesh::partition()
      0.80818          1.08783         6826    RecursiveBisection::operator()
      0.61757          0.83126         3413    GridSearch::operator()
      0.00250          0.00336            1    FluidEquations::init()
--------------------------------------------------------------------------------
```

- **After**:

```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
     74.10947        100.00000            1    main
     64.36031         86.84493        34130    EulerIntegrator::step()
     20.82860         28.10518        34130    FluidEquations::compute_density()
     16.90729         22.81394         3413    ParticleMesh::update()            <--
     15.87766         21.42460        34130    FluidEquations::setup_boundary()
     14.44310         19.48887         3413    ParticleMesh::search()            <--
      9.88639         13.34026        34130    FluidEquations::compute_forces()
      2.46300          3.32347         3413    ParticleMesh::partition()         <--
      0.81861          1.10460         6826    RecursiveBisection::operator()
      0.43866          0.59190         3413    GridSearch::operator()            <--
      0.00012          0.00017            1    FluidEquations::init()
--------------------------------------------------------------------------------
```