### PR TITLE
Use Mimalloc as our default allocator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(
 find_package(doctest CONFIG REQUIRED)
 find_package(HDF5 CONFIG REQUIRED)
 find_package(hwy CONFIG REQUIRED)
+find_package(mimalloc CONFIG REQUIRED)
 find_package(TBB CONFIG REQUIRED)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/core/CMakeLists.txt
+++ b/source/tit/core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_tit_library(
     "io.cpp"
     "main_func.cpp"
     "main_func.hpp"
+    "malloc.cpp"
     "mat.hpp"
     "mat/mat.hpp"
     "mat/eig.hpp"
@@ -70,6 +71,7 @@ add_tit_library(
     Boost::core
     Boost::stacktrace_addr2line
     hwy::hwy
+    mimalloc-static
     TBB::tbb
     TBB::tbbmalloc
 )

--- a/source/tit/core/malloc.cpp
+++ b/source/tit/core/malloc.cpp
@@ -1,0 +1,6 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include <mimalloc-new-delete.h> // IWYU pragma: keep

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,7 @@
     "doctest",
     "hdf5",
     "highway",
+    "mimalloc",
     "nanobench",
     "tbb"
   ]


### PR DESCRIPTION
Experiments show that `mi-malloc` provides slightly better performance with low effort, so why not using it.