### PR TITLE
Explicitly install autoconf.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           ## Fetch fresh packages, but do not upgrade them automatically.
           brew update -q
           ## Install the toolchain.
-          brew install -q cmake
+          brew install -q automake cmake libtool pkg-config
           brew install -q gcc@14 || true # Might fail for unknown reason.
           ## Install LLVM.
           brew install -q llvm@18

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN <<EOF
   # Install packages.
   apt-get update -y
   apt-get install -y                                                           \
+    automake                                                                   \
     build-essential                                                            \
     clang-tidy-18                                                              \
     cmake                                                                      \
@@ -24,6 +25,7 @@ RUN <<EOF
     git                                                                        \
     g++-14                                                                     \
     gnupg                                                                      \
+    libtool                                                                    \
     ninja-build                                                                \
     pkg-config                                                                 \
     python3                                                                    \


### PR DESCRIPTION
Our CI has started failing recently because vcpkg was unable to configure several packages because `autoconf` was not found. This PR explicitly installs `autoconf` and fixes the pipelines.