### PR TITLE
Compile with Clang.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,6 +40,9 @@
 # * cppcoreguidelines-pro-bounds-constant-array-index:
 #   This check does not works correctly with our asserts.
 #
+# * misc-no-recursion:
+#   We need recusion is some in templated recurred lambdas.
+#
 # * modernize-use-nodiscard:
 #   I do not want to put `[[nodiscard]]` everywhere, especially on functions
 #   like `size()`. I want to use `[[nodiscard]]` only when it is really needed,
@@ -73,6 +76,7 @@ Checks: |
   -cppcoreguidelines-misleading-capture-default-by-value
   -cppcoreguidelines-pro-bounds-constant-array-index
   misc-*
+  -misc-no-recursion
   modernize-*
   -modernize-use-nodiscard
   performance-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-15]
-        compiler: [g++-14]
+        compiler: [g++-14, clang++-18]
         configuration: [Debug, Release]
       fail-fast: false
 

--- a/build/setup-ci-runner.sh
+++ b/build/setup-ci-runner.sh
@@ -37,7 +37,9 @@ setup-macos() {
     libtool              \
     "llvm@$LLVM_VERSION" \
     pkg-config
-  echo "$(brew --prefix llvm@$LLVM_VERSION)/bin" >> $GITHUB_PATH
+  local LLVM_PATH="$(brew --prefix llvm@$LLVM_VERSION)/bin"
+  ln -s "$LLVM_PATH/clang++" "$LLVM_PATH/clang++-$LLVM_VERSION"
+  echo "$LLVM_PATH" >> $GITHUB_PATH
 }
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cmake/clang_tidy.cmake
+++ b/cmake/clang_tidy.cmake
@@ -47,6 +47,20 @@ function(enable_clang_tidy TARGET_OR_ALIAS)
     --use-color
   )
 
+  # Disable a few checks when compiling with Clang.
+  # TODO: All the checks must be enabled at some point!
+  if(CXX_COMPILER STREQUAL "CLANG")
+    set(
+      LIBCPP_DISABLED_CHECKS
+      # False positives with standard headers, like <format> and <expected>.
+      -misc-include-cleaner
+      # Suppress error messages from Doctest.
+      -modernize-type-traits
+    )
+    list(JOIN LIBCPP_DISABLED_CHECKS "," LIBCPP_DISABLED_CHECKS)
+    list(APPEND CLANG_TIDY_ARGS "--checks=${LIBCPP_DISABLED_CHECKS}")
+  endif()
+
   # Setup "compilation" arguments for clang-tidy call.
   get_generated_compile_options(${TARGET} CLANG_TIDY_COMPILE_ARGS)
   list(

--- a/cmake/gnu.cmake
+++ b/cmake/gnu.cmake
@@ -8,7 +8,7 @@ include_guard()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Define minimal compiler version.
-set(GNU_MIN_VERSION "14.0.1")
+set(GNU_MIN_VERSION "14.2.0")
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -161,21 +161,37 @@ set(
   GNU_LINK_OPTIONS_RELEASE
   # Inherit common options.
   ${GNU_LINK_OPTIONS}
-  # Inherit optimization options (needed for LTO or PGO).
+  # Inherit optimization options.
   ${GNU_OPTIMIZE_OPTIONS}
 )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Define common debugging options.
+set(
+  GNU_DEBUG_OPTIONS
+  # Store debug information.
+  -g
+  # Optimize for debugging experience.
+  -Og
+)
 
 # Define compile options for "Debug" configuration.
 set(
   GNU_COMPILE_OPTIONS_DEBUG
   # Inherit common options.
   ${GNU_COMPILE_OPTIONS}
-  # Store debug information.
-  -g
-  # Optimize for debugging experience.
-  -Og
+  # Inherit debugging options.
+  ${GNU_DEBUG_OPTIONS}
+)
+
+# Define link options for "Debug" configuration.
+set(
+  GNU_LINK_OPTIONS_DEBUG
+  # Inherit common options.
+  ${GNU_LINK_OPTIONS}
+  # Inherit debugging options.
+  ${GNU_DEBUG_OPTIONS}
 )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/core/CMakeLists.txt
+++ b/source/tit/core/CMakeLists.txt
@@ -36,6 +36,7 @@ add_tit_library(
     "meta/set.hpp"
     "meta/type.hpp"
     "missing.hpp"
+    "missing.libc++.hpp"
     "missing.libstdc++.hpp"
     "par.hpp"
     "par/atomic.hpp"

--- a/source/tit/core/containers/multivector.hpp
+++ b/source/tit/core/containers/multivector.hpp
@@ -17,6 +17,7 @@
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
 #include "tit/core/containers/mdvector.hpp"
+#include "tit/core/missing.hpp" // IWYU pragma: keep
 #include "tit/core/par.hpp"
 #include "tit/core/utils.hpp"
 
@@ -32,7 +33,7 @@ public:
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   /// Construct an empty multivector.
-  constexpr Multivector() noexcept = default;
+  constexpr Multivector() = default;
 
   /// Construct a multivector from initial values.
   constexpr explicit Multivector(
@@ -80,7 +81,7 @@ public:
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   /// Clear the multivector.
-  constexpr void clear() noexcept {
+  constexpr void clear() noexcept { // NOLINT(*-exception-escape)
     TIT_ASSERT(!val_ranges_.empty(), "Value ranges must not be empty!");
     val_ranges_.clear(), val_ranges_.push_back(0);
     vals_.clear();

--- a/source/tit/core/io.cpp
+++ b/source/tit/core/io.cpp
@@ -25,3 +25,17 @@ void eprint_stacktrace(const Std::stacktrace& stacktrace) {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 } // namespace tit
+
+// Required on MacOS Sequoia.
+#if defined(__APPLE__) && defined(_LIBCPP_VERSION)
+// NOLINTBEGIN
+_LIBCPP_BEGIN_NAMESPACE_STD
+_LIBCPP_EXPORTED_FROM_ABI auto __is_posix_terminal(FILE* __stream) -> bool {
+  return isatty(fileno(__stream));
+}
+_LIBCPP_EXPORTED_FROM_ABI auto __get_ostream_file(ostream& /*__os*/) -> FILE* {
+  return nullptr;
+}
+_LIBCPP_END_NAMESPACE_STD
+// NOLINTEND
+#endif

--- a/source/tit/core/io.hpp
+++ b/source/tit/core/io.hpp
@@ -36,13 +36,6 @@ inline void eprintln() {
   std::cerr << '\n';
 }
 
-/// @todo Argumentless `println` is not supported by GCC 14.0.1.
-#if defined(__GLIBCXX__) && (__GLIBCXX__ < 20240507)
-inline void println() {
-  std::cout << '\n';
-}
-#endif
-
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Print the stack trace to the standard error stream.

--- a/source/tit/core/missing.hpp
+++ b/source/tit/core/missing.hpp
@@ -14,6 +14,9 @@
 #ifdef __GLIBCXX__
 #include "tit/core/missing.libstdc++.hpp"
 #endif
+#ifdef _LIBCPP_VERSION
+#include "tit/core/missing.libc++.hpp"
+#endif
 // IWYU pragma: end_exports
 
 namespace tit::Std {

--- a/source/tit/core/missing.libc++.hpp
+++ b/source/tit/core/missing.libc++.hpp
@@ -1,0 +1,162 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#pragma once
+
+#include <cstddef> // IWYU pragma: keep
+#ifdef _LIBCPP_VERSION
+
+#include <array>
+#include <charconv>
+#include <concepts>
+#include <functional>
+#include <iostream>
+#include <ranges>
+#include <sstream>
+#include <utility>
+
+#include "tit/core/uint_utils.hpp"
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Missing range adaptors.
+//
+
+namespace ranges::views {
+
+template<class Range>
+concept good_range =
+    std::ranges::viewable_range<Range> && std::ranges::sized_range<Range> &&
+    std::ranges::random_access_range<Range>;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// Simple implementation of `std::views::enumerate`.
+struct EnumerateAdaptor {
+  template<good_range Range>
+  constexpr auto operator()(Range&& range) const {
+    auto view = std::views::all(std::forward<Range>(range));
+    return std::views::iota(0UZ, std::ranges::size(range)) |
+           std::views::transform([view = std::move(view)](size_t index) {
+             return std::pair{index, view[index]};
+           });
+  }
+};
+
+inline constexpr EnumerateAdaptor enumerate{};
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// Simple implementation of `std::views::chunk`.
+struct ChunkAdaptor {
+  template<good_range Range>
+  constexpr auto operator()(Range&& range, size_t chunk_size) const {
+    auto view = std::views::all(std::forward<Range>(range));
+    const auto num_chunks = tit::divide_up(std::ranges::size(view), chunk_size);
+    return std::views::iota(0UZ, num_chunks) |
+           std::views::transform(
+               [view = std::move(view), chunk_size](size_t chunk_index) {
+                 const auto sz = std::ranges::size(view);
+                 const auto first = std::min(sz, chunk_index * chunk_size);
+                 const auto last = std::min(sz, (chunk_index + 1) * chunk_size);
+                 const auto iter = std::ranges::begin(view);
+                 return std::ranges::subrange(iter + first, iter + last);
+               });
+  }
+};
+
+inline constexpr ChunkAdaptor chunk{};
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// Simple implementation of `std::views::adjacent_transform`.
+template<size_t N>
+struct AdjacentTransformAdaptor {
+  static_assert(N == 2, "Only two adjacent elements are supported!");
+  template<good_range Range, class Func>
+  constexpr auto operator()(Range&& range, Func func) const {
+    auto view = std::views::all(std::forward<Range>(range));
+    return std::views::iota(0UZ, std::ranges::size(range) - 1) |
+           std::views::transform(
+               [view = std::move(view), func = std::move(func)](size_t index) {
+                 return func(std::ranges::begin(view)[index],
+                             std::ranges::begin(view)[index + 1]);
+               });
+  }
+  template<class Func>
+  constexpr auto operator()(Func func) const {
+    return __range_adaptor_closure_t(std::__bind_back(*this, func));
+  }
+};
+
+template<size_t N>
+inline constexpr AdjacentTransformAdaptor<N> adjacent_transform{};
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+// Simple implementation of `std::views::cartesian_product`.
+// This simple implementation requires all ranges to have the same value type.
+struct CartesianProductAdaptor {
+  template<good_range... Ranges>
+  constexpr auto operator()(Ranges&&... ranges) const {
+    static constexpr auto Dim = sizeof...(Ranges);
+    const auto flat_size = (std::ranges::size(ranges) * ...);
+    std::array views{std::views::all(std::forward<Ranges>(ranges))...};
+    using Elem = decltype(auto(views[0][0]));
+    return std::views::iota(0UZ, flat_size) |
+           std::views::transform([views = std::move(views)](size_t flat_index) {
+             std::array<Elem, Dim> items{};
+             for (ssize_t axis = Dim - 1; axis >= 0; --axis) {
+               const auto size = std::ranges::size(views[axis]);
+               const auto index = flat_index % size;
+               items[axis] = views[axis][index];
+               flat_index /= size;
+             }
+             return items;
+           });
+  }
+};
+
+inline constexpr CartesianProductAdaptor cartesian_product{};
+
+} // namespace ranges::views
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Miscellaneous.
+//
+
+// Argumentless `println` is not implemented in libc++.
+inline void println() {
+  std::cout << '\n';
+}
+
+// `std::bind_back` is a private implementation detail.
+template<class Func, class... BackArgs>
+constexpr auto bind_back(Func&& func, BackArgs&&... back_arguments) {
+  return __bind_back(std::forward<Func>(func),
+                     std::forward<BackArgs>(back_arguments)...);
+}
+
+// `std::from_chars` does not support floating-point types.
+template<std::floating_point Float>
+auto from_chars(const char* first, // NOLINT(*-exception-escape)
+                const char* last,
+                Float& result,
+                std::chars_format /*fmt*/ = std::chars_format::general) noexcept
+    -> std::from_chars_result {
+  std::istringstream stream{std::string{first, last}};
+  stream >> result;
+  if (stream.fail()) return {first, std::errc::invalid_argument};
+  return {last, std::errc{}}; // NOLINT
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // ifdef _LIBCPP_VERSION

--- a/source/tit/core/stats.hpp
+++ b/source/tit/core/stats.hpp
@@ -124,7 +124,7 @@ public:
   /// Update the statistics variable.
   void update(const Vals& range) {
     for (const auto& [i, val] :
-         range | std::views::take(sum_.size()) | std::views::enumerate) {
+         std::views::enumerate(range) | std::views::take(sum_.size())) {
       sum_[i] += val;
       min_[i] = std::min(min_[i], val);
       max_[i] = std::max(max_[i], val);

--- a/source/tit/core/str_utils.hpp
+++ b/source/tit/core/str_utils.hpp
@@ -18,6 +18,7 @@
 #include <unordered_set>
 
 #include "tit/core/basic_types.hpp"
+#include "tit/core/missing.hpp" // IWYU pragma: keep
 
 namespace tit {
 

--- a/source/tit/core/sys_utils.hpp
+++ b/source/tit/core/sys_utils.hpp
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <typeinfo>
 
 #include <unistd.h>
 

--- a/source/tit/geom/bbox.hpp
+++ b/source/tit/geom/bbox.hpp
@@ -124,7 +124,7 @@ public:
     return [&point]<size_t Axis>(this const auto& self,
                                  integral_constant_t<Axis> /*axis*/,
                                  const auto&... boxes) {
-      const auto split_boxes = array_cat(boxes.split(Axis, point[Axis])...);
+      auto split_boxes = array_cat(boxes.split(Axis, point[Axis])...);
       if constexpr (Axis == vec_dim_v<Vec> - 1) {
         return split_boxes;
       } else {

--- a/source/tit/geom/grid.hpp
+++ b/source/tit/geom/grid.hpp
@@ -10,6 +10,7 @@
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
+#include "tit/core/missing.hpp" // IWYU pragma: keep
 #include "tit/core/vec.hpp"
 
 #include "tit/geom/bbox.hpp"
@@ -35,9 +36,8 @@ public:
   constexpr Grid() = default;
 
   /// Initialize a grid with the given bounding box and number of cells.
-  constexpr explicit Grid(const Box& box,
-                          const VecIndex& num_cells = VecIndex(1))
-      : box_{box} {
+  constexpr explicit Grid(Box box, const VecIndex& num_cells = VecIndex(1))
+      : box_{std::move(box)} {
     set_num_cells(num_cells);
   }
 

--- a/source/tit/sph/particle_mesh.hpp
+++ b/source/tit/sph/particle_mesh.hpp
@@ -17,6 +17,7 @@
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
 #include "tit/core/containers/multivector.hpp"
+#include "tit/core/missing.hpp" // IWYU pragma: keep
 #include "tit/core/par.hpp"
 #include "tit/core/profiler.hpp"
 #include "tit/core/stats.hpp"

--- a/tests/tit/core/CMakeLists.txt
+++ b/tests/tit/core/CMakeLists.txt
@@ -35,6 +35,7 @@ add_tit_test_from_target(
   NAME "tit/core/catch_fatal_signal"
   EXIT_CODE 1
   MATCH_STDERR "catch_fatal_signal_stderr.txt"
+  FILTERS "s/SIG.+$/<SIGNAL>./g" # Simplify signal name.
   FILTERS "/0x*/d" # Remove everything related to the stack trace.
 )
 
@@ -51,6 +52,7 @@ add_tit_test_from_target(
   NAME "tit/core/catch_std_exception"
   EXIT_CODE 1
   MATCH_STDERR "catch_std_exception_stderr.txt"
+  FILTERS "/basic_string/d" # Remove platform-specific error message.
   FILTERS "/0x*/d" # Remove everything related to the stack trace.
 )
 


### PR DESCRIPTION
We can now compile with `clang++-18`. Performance needs to be fixed at some point:
```
--------------------------------------------------------------------------------
abs. time [s]    rel. time [%]    calls [#]    section name
--------------------------------------------------------------------------------
    114.08089        100.00000            1    main
    104.48386         91.58752        34130    EulerIntegrator::step()
     51.40860         45.06329        34130    FluidEquations::compute_density()
     24.24966         21.25655         3413    ParticleMesh::update()
     21.85574         19.15811         3413    ParticleMesh::search()
     17.16157         15.04333        34130    FluidEquations::setup_boundary()
     10.70563          9.38425        34130    FluidEquations::compute_forces()
      2.39285          2.09750         3413    ParticleMesh::partition()
      0.81649          0.71571         6826    RecursiveBisection::operator()
      0.38143          0.33435         3413    GridSearch::operator()
      0.00011          0.00009            1    FluidEquations::init()
--------------------------------------------------------------------------------
```