### PR TITLE
Fix constexpr math.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(
     stacktrace_addr2line
 )
 find_package(doctest CONFIG REQUIRED)
+find_package(gcem CONFIG REQUIRED)
 find_package(HDF5 CONFIG REQUIRED)
 find_package(hwy CONFIG REQUIRED)
 find_package(metis CONFIG REQUIRED)

--- a/source/tit/core/CMakeLists.txt
+++ b/source/tit/core/CMakeLists.txt
@@ -71,6 +71,7 @@ add_tit_library(
     Boost::core
     Boost::container
     Boost::stacktrace_addr2line
+    gcem
     hwy::hwy
     mimalloc-static
     TBB::tbb

--- a/source/tit/core/sys_utils.cpp
+++ b/source/tit/core/sys_utils.cpp
@@ -53,6 +53,14 @@ void fast_exit(ExitCode exit_code) noexcept {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+void checked_system(const char* command) noexcept {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe,cert-env33-c)
+  const auto status = std::system(command);
+  TIT_ENSURE(status == 0, "System command failed!");
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 auto tty_width(TTY tty) noexcept -> std::optional<size_t> {
   const auto tty_fileno = static_cast<int>(tty);
   if (isatty(tty_fileno) == 0) return std::nullopt; // Redirected.

--- a/source/tit/core/sys_utils.hpp
+++ b/source/tit/core/sys_utils.hpp
@@ -40,6 +40,11 @@ void fast_exit(ExitCode exit_code) noexcept;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// Execute a system command. Fail if the command fails.
+void checked_system(const char* command) noexcept;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Terminal stream type.
 enum class TTY : uint8_t {
   Stdout = STDOUT_FILENO, ///< Standard output.

--- a/source/tit/sph/fluid_equations.hpp
+++ b/source/tit/sph/fluid_equations.hpp
@@ -321,6 +321,7 @@ public:
 #endif
     });
     par::for_each(particles.fluid(), [this](PV a) {
+      static_cast<void>(this); // Maybe unused.
 #if WITH_GRAVITY
       // TODO: Gravity.
       dv_dt[a][1] -= 9.81;

--- a/source/titesph/esph.cpp
+++ b/source/titesph/esph.cpp
@@ -1,15 +1,13 @@
-#include <cassert>
-#include <cmath>
-#include <cstddef>
+#define WITH_GRAVITY 1
+
 #include <cstdint>
 #include <format>
-
-#define WITH_GRAVITY 1
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/io.hpp"
 #include "tit/core/main_func.hpp"
 #include "tit/core/meta.hpp"
+#include "tit/core/sys_utils.hpp"
 #include "tit/core/time.hpp"
 #include "tit/core/vec.hpp"
 
@@ -21,21 +19,12 @@
 #include "tit/sph/particle_mesh.hpp"
 #include "tit/sph/time_integrator.hpp"
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-namespace {
-void my_system(const char* command) {
-  std::system(command); // NOLINT
-}
-} // namespace
+namespace tit::sph {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template<class Real>
 auto sph_main(int /*argc*/, char** /*argv*/) -> int {
-  using namespace tit;
-  using namespace sph;
-
   constexpr Real H = 0.01; // Bar height.
   constexpr Real L = 0.10; // Bar length.
 
@@ -46,8 +35,8 @@ auto sph_main(int /*argc*/, char** /*argv*/) -> int {
   constexpr Real dt = 1.0e-5; // 0.008 * h_0 / cs_0
 
   constexpr int N_fixed = 1;
-  constexpr int BAR_M(L / dr);
-  constexpr int BAR_N(H / dr);
+  constexpr int BAR_M = int(round(L / dr));
+  constexpr int BAR_N = int(round(H / dr));
 
   constexpr Real g = 9.81;
   constexpr Real m_0 = rho_0 * pow2(dr);
@@ -99,7 +88,7 @@ auto sph_main(int /*argc*/, char** /*argv*/) -> int {
   ParticleMesh mesh{geom::KDTreeSearch{}};
 
   print_csv(particles, "output/test_output/particles-0.csv");
-  my_system("ln -sf output/test_output/particles-0.csv particles.csv");
+  checked_system("ln -sf output/test_output/particles-0.csv particles.csv");
 
   Real time{};
   Stopwatch exectime{};
@@ -119,7 +108,7 @@ auto sph_main(int /*argc*/, char** /*argv*/) -> int {
       const auto path =
           std::format("output/test_output/particles-{}.csv", n / 200);
       print_csv(particles, path);
-      my_system(("ln -sf ./" + path + " particles.csv").c_str());
+      checked_system(("ln -sf ./" + path + " particles.csv").c_str());
     }
     if (time * sqrt(g / H) > 6.90e+6) break;
     time += dt;
@@ -132,8 +121,8 @@ auto sph_main(int /*argc*/, char** /*argv*/) -> int {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-auto main(int argc, char** argv) -> int {
-  return tit::run_main(argc, argv, &sph_main<tit::real_t>);
-}
+} // namespace tit::sph
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+auto main(int argc, char** argv) -> int {
+  return tit::run_main(argc, argv, &tit::sph::sph_main<tit::real_t>);
+}

--- a/source/titwcsph/CMakeLists.txt
+++ b/source/titwcsph/CMakeLists.txt
@@ -3,23 +3,14 @@
 # See /LICENSE.md for license information. SPDX-License-Identifier: MIT
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Specify the list of sources.
-set(
-  CXX_SOURCES
-  "wcsph.cpp"
+add_tit_executable(
+  NAME
+    titwcsph
+  SOURCES
+    "wcsph.cpp"
+  DEPENDS
+    tit::core
+    tit::sph
 )
-
-# Create the executable.
-add_executable(titwcsph ${CXX_SOURCES})
-add_executable(tit::wcsph ALIAS titwcsph)
-
-# Link with the dependent libraries.
-target_link_libraries(titwcsph PRIVATE tit::sph)
-
-# Enable static analysis.
-# enable_clang_tidy(tit::wcsph)
-
-# Install the executable.
-install(TARGETS titwcsph RUNTIME DESTINATION bin)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/titwcsph/CMakeLists.txt
+++ b/tests/titwcsph/CMakeLists.txt
@@ -8,7 +8,7 @@
 # reason of not breaking anything while doing some deep refactoring in the
 # library core.
 add_tit_test_from_target(
-  tit::wcsph
+  tit::titwcsph
   NAME "titwcsph/dam_breaking[long]"
   MATCH_FILES "particles.csv.checksum"
 )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,7 @@
     "boost-container",
     "boost-stacktrace",
     "doctest",
+    "gcem",
     "hdf5",
     "highway",
     "metis",


### PR DESCRIPTION
This PR implements `constexpr`-friendly math functions for Clang. It fixes all issues with LLVM tools under `libstdc++` and allows us to finally use our wrappers on all targets.