### PR TITLE
Clean-up the build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ find_package(
 )
 find_package(doctest CONFIG REQUIRED)
 find_package(gcem CONFIG REQUIRED)
-find_package(HDF5 CONFIG REQUIRED)
 find_package(hwy CONFIG REQUIRED)
 find_package(metis CONFIG REQUIRED)
 find_package(mimalloc CONFIG REQUIRED)
@@ -71,12 +70,6 @@ foreach(CONFIG ${ALL_CONFIGS})
   )
 endforeach()
 
-# Link with the dependent libraries.
-target_link_libraries(
-  tit_base INTERFACE
-  hdf5::hdf5-static
-)
-
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Add the actual sources.
@@ -86,7 +79,7 @@ add_subdirectory("tests")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Write "compile_flags.txt" based on the container library.
-write_compile_flags(tit::base)
+write_compile_flags(tit::core)
 
 # Enable global static analysis.
 check_spelling(${CMAKE_PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ project(tit VERSION 0.1 LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(clangd)
 include(codespell)
-include(compiler)
 include(tit_target)
 include(tit_testing)
 
@@ -26,10 +25,7 @@ include(tit_testing)
 find_package(
   Boost
   CONFIG REQUIRED
-  COMPONENTS
-    core
-    container
-    stacktrace_addr2line
+  COMPONENTS core container stacktrace_addr2line
 )
 find_package(doctest CONFIG REQUIRED)
 find_package(gcem CONFIG REQUIRED)
@@ -40,48 +36,16 @@ find_package(TBB CONFIG REQUIRED)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Setup C++ globally.
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-set(CMAKE_CXX_EXTENSIONS NO)
-
-# A container library that stores all the properties.
-# Other libraries and executables should link with this library.
-add_library(tit_base INTERFACE)
-add_library(tit::base ALIAS tit_base)
-
-# Setup include directories.
-target_include_directories(tit_base INTERFACE "source")
-
-# Setup configurations.
-foreach(CONFIG ${ALL_CONFIGS})
-  string(TOUPPER ${CONFIG} CONFIG_UPPER)
-
-  # Apply compilation options.
-  target_compile_options(
-    tit_base INTERFACE
-    $<$<CONFIG:${CONFIG}>:${CXX_COMPILE_OPTIONS_${CONFIG_UPPER}}>
-  )
-
-  # Apply link options.
-  target_link_options(
-    tit_base INTERFACE
-    $<$<CONFIG:${CONFIG}>:${CXX_LINK_OPTIONS_${CONFIG_UPPER}}>
-  )
-endforeach()
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 # Add the actual sources.
 add_subdirectory("source")
 add_subdirectory("tests")
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Write "compile_flags.txt" based on the container library.
+# Write "compile_flags.txt" based on the core library.
 write_compile_flags(tit::core)
 
-# Enable global static analysis.
-check_spelling(${CMAKE_PROJECT_NAME})
+# Enable spell checking.
+check_spelling()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/build/setup-ci-runner.sh
+++ b/build/setup-ci-runner.sh
@@ -70,6 +70,7 @@ install-vcpkg() {
   export VCPKG_DEFAULT_BINARY_CACHE="$HOME/vcpkg_cache"
   echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
   echo "VCPKG_DEFAULT_BINARY_CACHE=$VCPKG_DEFAULT_BINARY_CACHE" >> $GITHUB_ENV
+  # Note: we cannot use `--depth=1` here, vcpgk requires the baseline commit.
   git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
   "$VCPKG_ROOT/bootstrap-vcpkg.sh"
   mkdir -p $VCPKG_DEFAULT_BINARY_CACHE || true # Ignore if it already exists.

--- a/build/setup-ci-runner.sh
+++ b/build/setup-ci-runner.sh
@@ -70,7 +70,7 @@ install-vcpkg() {
   export VCPKG_DEFAULT_BINARY_CACHE="$HOME/vcpkg_cache"
   echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
   echo "VCPKG_DEFAULT_BINARY_CACHE=$VCPKG_DEFAULT_BINARY_CACHE" >> $GITHUB_ENV
-  git clone --depth=1 https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
+  git clone https://github.com/microsoft/vcpkg.git $VCPKG_ROOT
   "$VCPKG_ROOT/bootstrap-vcpkg.sh"
   mkdir -p $VCPKG_DEFAULT_BINARY_CACHE || true # Ignore if it already exists.
 }

--- a/cmake/clang.cmake
+++ b/cmake/clang.cmake
@@ -57,7 +57,7 @@ set(
   -march=native
 )
 
-# When compiling with libstdc++, ensure is is properly configured.
+# When compiling with libstdc++, ensure Clang is properly configured.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR NOT APPLE)
   list(
     APPEND
@@ -106,10 +106,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND APPLE)
     -stdlib++-isystem "${STDCPP_INCLUDE_DIR}"
     -cxx-isystem "${STDCPP_SYS_INCLUDE_DIR}"
   )
-
-  # Clear variables.
-  unset(STDCPP_INCLUDE_DIR)
-  unset(STDCPP_SYS_INCLUDE_DIR)
 endif()
 
 # Define common link options.

--- a/cmake/clang_tidy.cmake
+++ b/cmake/clang_tidy.cmake
@@ -10,17 +10,16 @@ include(utils)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Find clang-tidy (at least 18.1.3). Prefer version-suffixed executables.
-find_program_with_version(
-  CLANG_TIDY_EXE
-  NAMES "clang-tidy-18" "clang-tidy"
-  MIN_VERSION "18.1.3"
-)
+find_program(CLANG_TIDY_EXE NAMES "clang-tidy-18" "clang-tidy")
+if(NOT CLANG_TIDY_EXE)
+  message(WARNING "clang-tidy was not found!")
+endif()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-##
-## Analyze source code with clang-tidy.
-##
+#
+# Analyze source code with clang-tidy.
+#
 function(enable_clang_tidy TARGET_OR_ALIAS)
   # Should we skip analysis?
   if(SKIP_ANALYSIS)
@@ -53,6 +52,7 @@ function(enable_clang_tidy TARGET_OR_ALIAS)
     set(
       LIBCPP_DISABLED_CHECKS
       # False positives with standard headers, like <format> and <expected>.
+      # Looks like this issue is fixed in LLVM 19.
       -misc-include-cleaner
       # Suppress error messages from Doctest.
       -modernize-type-traits
@@ -68,7 +68,7 @@ function(enable_clang_tidy TARGET_OR_ALIAS)
     CLANG_TIDY_COMPILE_ARGS
     # Inherit compile options we would use for compilation.
     ${CLANG_COMPILE_OPTIONS}
-    # Enable C++23.
+    # Enable C++23, as it is not configured by the compile options.
     -std=c++23
   )
 

--- a/cmake/clangd.cmake
+++ b/cmake/clangd.cmake
@@ -8,34 +8,32 @@ include(clang)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-## Write the `compile_flags.txt` for the clangd language server.
-function(write_compile_flags TARGET_OR_ALIAS)
-  # Get the original target name if it is an alias.
-  get_target_property(TARGET ${TARGET_OR_ALIAS} ALIASED_TARGET)
-  if(NOT TARGET ${TARGET})
-    set(TARGET ${TARGET_OR_ALIAS})
-  endif()
-
-  # Setup "compilation" arguments for mock "clang" call.
+#
+# Write the `compile_flags.txt` for the clangd language server.
+#
+# TODO: In a better world, we would simply use `CMAKE_EXPORT_COMPILE_COMMANDS`.
+#
+function(write_compile_flags SAMPLE_TARGET)
+  # Setup "compilation" arguments for hypothetical "clang" call.
   set(CLANG_COMPILE_ARGS)
-  get_generated_compile_options(${TARGET} CLANG_COMPILE_ARGS)
+  get_generated_compile_options(${SAMPLE_TARGET} CLANG_COMPILE_ARGS)
   list(
     APPEND
     CLANG_COMPILE_ARGS
-    # Enable the same set of compile options we would use for normal clang call.
+    # Inherit compile options we would use for compilation.
     ${CLANG_COMPILE_OPTIONS}
-    # Enable C++23.
+    # Enable C++23, as it is not configured by the compile options.
     -std=c++23
   )
 
   # Write the compile flags to a file, each on a new line.
   add_custom_target(
-    "${TARGET}_clangd_compile_flags"
-    ALL
+    "${CMAKE_PROJECT_NAME}_clangd_compile_flags"
+    ALL # Execute on every build.
     COMMAND
       "${CMAKE_COMMAND}" -E echo ${CLANG_COMPILE_ARGS} |
-      xargs -n 1 > "${CMAKE_CURRENT_SOURCE_DIR}/compile_flags.txt"
-    COMMENT "Writing compile_flags.txt"
+      xargs -n 1 > "${CMAKE_SOURCE_DIR}/compile_flags.txt"
+    COMMENT "Writing compile_flags.txt for clangd"
     COMMAND_EXPAND_LISTS # Needed for generator expressions to work.
     VERBATIM
   )

--- a/cmake/codespell.cmake
+++ b/cmake/codespell.cmake
@@ -9,33 +9,17 @@ include(utils)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Find codespell.
-find_program(
-  CODESPELL_EXE
-  NAMES "codespell"
-)
-
-# Find list of words for codespell to ignore.
-if(CODESPELL_EXE)
-  find_file(
-    CODESPELL_IGNORE_PATH
-    NAMES "codespell.txt"
-    PATHS "${CMAKE_SOURCE_DIR}/cmake"
-    REQUIRED
-  )
+find_program(CODESPELL_EXE NAMES "codespell")
+if(NOT CODESPELL_EXE)
+  message(WARNING "codespell was not found!")
 endif()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-##
-## Check spelling in the specified directory.
-##
-## Unlike other static analysis tools, I do not want to run spellcheck pear each
-## target separately. There two issues: first, codespell is written in Python,
-## and it's startup and execution times can be better, so it will slow down our
-## build; second, I want spell checking in all indexed files, not just source
-## files.
-##
-function(check_spelling TARGET)
+#
+# Check spelling in the specified directory.
+#
+function(check_spelling)
   # Should we skip analysis?
   if(SKIP_ANALYSIS)
     return()
@@ -49,32 +33,34 @@ function(check_spelling TARGET)
   # We'll check indexed files only. The best way to do this is to ask git
   # what files are indexed in the directory, and pass those to codespell.
   execute_process(
-    COMMAND ${GIT_EXE} ls-files "${CMAKE_CURRENT_SOURCE_DIR}"
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMAND "${GIT_EXE}" ls-files
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     OUTPUT_VARIABLE INDEXED_FILES
   )
+  string(STRIP "${INDEXED_FILES}" INDEXED_FILES)
   string(REPLACE "\n" ";" INDEXED_FILES "${INDEXED_FILES}")
+  list(TRANSFORM INDEXED_FILES STRIP)
+  list(TRANSFORM INDEXED_FILES PREPEND "${CMAKE_SOURCE_DIR}/")
 
   # Create a stamp.
-  set(STAMP "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.spell_stamp")
+  set(STAMP "${CMAKE_BINARY_DIR}/${TARGET}.spell_stamp")
 
   # Run codespell.
   add_custom_command(
-    COMMENT "Checking spelling in ${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMENT "Checking spelling in ${CMAKE_SOURCE_DIR}"
     OUTPUT "${STAMP}"
     COMMAND
       "${CODESPELL_EXE}"
-        --ignore-words="${CODESPELL_IGNORE_PATH}"
+        --ignore-words="${CMAKE_SOURCE_DIR}/cmake/codespell.txt"
         --check-filenames
         ${INDEXED_FILES}
     COMMAND
       "${CMAKE_COMMAND}" -E touch "${STAMP}"
     DEPENDS ${INDEXED_FILES}
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" # Codespell uses relative paths.
   )
 
   # Add target that would be built once documentation files are updated.
-  add_custom_target("${TARGET}_codespell" ALL DEPENDS "${STAMP}")
+  add_custom_target("${CMAKE_PROJECT_NAME}_codespell" ALL DEPENDS "${STAMP}")
 endfunction()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -38,14 +38,14 @@ endif()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Set compiler ID.
+# Set the compiler ID.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   set(CXX_COMPILER "CLANG")
 else()
   string(TOUPPER ${CMAKE_CXX_COMPILER_ID} CXX_COMPILER)
 endif()
 
-# Check if compiler is known...
+# Check if compiler is known and it's version is sufficient.
 try_set(CXX_COMPILER_MIN_VERSION "${CXX_COMPILER}_MIN_VERSION")
 if(NOT DEFINED CXX_COMPILER_MIN_VERSION)
   message(
@@ -53,7 +53,6 @@ if(NOT DEFINED CXX_COMPILER_MIN_VERSION)
     "Compiler ${CMAKE_CXX_COMPILER_ID} is not supported."
   )
 endif()
-# ...and it's version is sufficient.
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${CXX_COMPILER_MIN_VERSION})
   message(
     FATAL_ERROR
@@ -61,9 +60,6 @@ if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${CXX_COMPILER_MIN_VERSION})
     "Minimum required version is ${CXX_COMPILER_MIN_VERSION}."
   )
 endif()
-
-# Setup warnings and diagnostics options.
-try_set(CXX_WARNINGS "${CXX_COMPILER}_WARNINGS")
 
 # Setup compile options.
 try_set(CXX_COMPILE_OPTIONS "${CXX_COMPILER}_COMPILE_OPTIONS")

--- a/cmake/tit_testing.cmake
+++ b/cmake/tit_testing.cmake
@@ -20,9 +20,9 @@ find_program(
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-##
-## Register the test command.
-##
+#
+# Register the test command.
+#
 function(add_tit_test)
   # Parse and check arguments.
   cmake_parse_arguments(
@@ -87,9 +87,9 @@ endfunction()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-##
-## Register the test target.
-##
+#
+# Register the test target.
+#
 function(add_tit_test_from_target TARGET)
   # Parse and check arguments.
   if(NOT TARGET)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -24,116 +24,13 @@ find_program(GIT_EXE NAMES "git" REQUIRED)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-##
-## Get program version.
-##
-## Program version is determined by executing the program with `--version`
-## option and searching for the first occurrence of two or more numbers,
-## which are separated by a dot symbol.
-##
-function(get_program_version PROG_EXE PROG_VERSION_VAR)
-  # Check arguments.
-  if(NOT PROG_EXE)
-    message(FATAL_ERROR "Program path must be specified.")
-  endif()
-
-  # Run the executable to get its version.
-  execute_process(
-    COMMAND ${PROG_EXE} --version
-    RESULT_VARIABLE PROCESS_RESULT
-    OUTPUT_VARIABLE PROCESS_OUTPUT
-  )
-  if(NOT PROCESS_RESULT EQUAL 0)
-    message(FATAL_ERROR "Could not execute ${PROG_EXE} --version")
-  endif()
-
-  # Extract the full version string.
-  string(REGEX MATCH "[0-9]+(\\.[0-9]+)+" PROG_VERSION "${PROCESS_OUTPUT}")
-  if(NOT PROG_VERSION)
-    message(FATAL_ERROR "Could not find a version number.")
-  endif()
-
-  # Propagate the version variable to parent scope.
-  set(${PROG_VERSION_VAR} ${PROG_VERSION} PARENT_SCOPE)
-endfunction()
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-##
-## Find a program and check whether it's version is sufficient.
-##
-## This mostly function replicates interface of the original `find_program`,
-## adding the additional mandatory `MIN_VERSION` keyword-prefixed argument.
-##
-function(find_program_with_version PROG_EXE_VAR)
-  # Parse and check arguments.
-  cmake_parse_arguments(
-    PROG
-    "REQUIRED;NO_CACHE"
-    "MIN_VERSION"
-    "NAMES;HINTS;PATHS"
-    ${ARGN}
-  )
-  if(NOT PROG_NAMES)
-    message(FATAL_ERROR "Program names must be specified.")
-  endif()
-  if(NOT PROG_MIN_VERSION)
-    message(FATAL_ERROR "Program minimal version must be specified.")
-  endif()
-
-  # Search for the program. Do not cache the result yet.
-  find_program(
-    PROG_EXE
-    NAMES ${PROG_NAMES}
-    HINTS ${PROG_HINTS}
-    PATHS ${PROG_PATHS}
-    NO_CACHE
-  )
-  if(NOT PROG_EXE)
-    if(PROG_REQUIRED)
-      list(JOIN PROG_NAMES ", " PROG_NAMES)
-      message(
-        FATAL_ERROR
-        "Count not find ${PROG_EXE_VAR} using the following names: "
-        ${PROG_NAMES}
-      )
-    endif()
-    return()
-  endif()
-
-  # Check program version.
-  get_program_version(${PROG_EXE} PROG_VERSION)
-  if(PROG_VERSION VERSION_LESS ${PROG_MIN_VERSION})
-    if(PROG_REQUIRED)
-      set(MESSAGE_LEVEL FATAL_ERROR)
-    else()
-      set(MESSAGE_LEVEL WARNING)
-    endif()
-    message(
-      ${MESSAGE_LEVEL}
-      "Insufficient version ${PROG_VERSION} of ${PROG_EXE_VAR} was found. "
-      "Minimum required version is ${PROG_MIN_VERSION}."
-    )
-    return()
-  endif()
-
-  # Propagate the program path to parent scope or cache on success.
-  if(PROG_NO_CACHE)
-    set(${PROG_EXE_VAR} ${PROG_EXE} PARENT_SCOPE)
-  else()
-    set(${PROG_EXE_VAR} ${PROG_EXE} CACHE INTERNAL "Path to ${PROG_EXE_VAR}")
-  endif()
-endfunction()
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 # A list of the C/C++ source file extensions.
 set(CPP_HEADER_EXTENSIONS ".h" ".hpp" ".hxx" ".h++" ".hh")
 set(CPP_SOURCE_EXTENSIONS ".c" ".cpp" ".cxx" ".c++" ".cc")
 
-##
-## Determine if file is a C/C++ header file based on it's extension.
-##
+#
+# Determine if file is a C/C++ header file based on it's extension.
+#
 function(is_cpp_header SOURCE_PATH RESULT_VAR)
   get_filename_component(SOURCE_EXTENSION ${SOURCE_PATH} LAST_EXT)
   string(TOLOWER ${SOURCE_EXTENSION} SOURCE_EXTENSION)
@@ -144,9 +41,9 @@ function(is_cpp_header SOURCE_PATH RESULT_VAR)
   endif()
 endfunction()
 
-##
-## Determine if file is a C/C++ source file based on it's extension.
-##
+#
+# Determine if file is a C/C++ source file based on it's extension.
+#
 function(is_cpp_source SOURCE_PATH RESULT_VAR)
   get_filename_component(SOURCE_EXTENSION ${SOURCE_PATH} LAST_EXT)
   string(TOLOWER ${SOURCE_EXTENSION} SOURCE_EXTENSION)
@@ -157,9 +54,9 @@ function(is_cpp_source SOURCE_PATH RESULT_VAR)
   endif()
 endfunction()
 
-##
-## Determine if file is a C/C++ file based on it's extension.
-##
+#
+# Determine if file is a C/C++ file based on it's extension.
+#
 function(is_cpp_file SOURCE_PATH RESULT_VAR)
   is_cpp_header(${SOURCE_PATH} IS_HEADER)
   is_cpp_source(${SOURCE_PATH} IS_SOURCE)
@@ -172,10 +69,10 @@ endfunction()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-##
-## Get a selected subset of the target's compile options: include directories
-## and compile definitions.
-##
+#
+# Get a selected subset of the target's compile options: include directories
+# and compile definitions.
+#
 macro(get_generated_compile_options TARGET OPTIONS_VAR)
   # Append include directories.
   foreach(PROP INCLUDE_DIRECTORIES INTERFACE_INCLUDE_DIRECTORIES)
@@ -201,10 +98,10 @@ endmacro()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-##
-## Read value from the variable by it's name, if it is defined.
-## If it is undefined and default values are provided, those are set.
-##
+#
+# Read value from the variable by it's name, if it is defined.
+# If it is undefined and default values are provided, those are set.
+#
 macro(try_set VAR VAR_NAME)
   if(DEFINED ${VAR_NAME})
     set(${VAR} ${${VAR_NAME}})

--- a/source/tit/core/CMakeLists.txt
+++ b/source/tit/core/CMakeLists.txt
@@ -69,7 +69,6 @@ add_tit_library(
     "vec/vec.hpp"
     "vec/vec_mask.hpp"
   DEPENDS
-    tit::base
     Boost::core
     Boost::container
     Boost::stacktrace_addr2line

--- a/source/tit/testing/CMakeLists.txt
+++ b/source/tit/testing/CMakeLists.txt
@@ -17,7 +17,6 @@ add_tit_library(
     "test_main.cpp"
     "utils.hpp"
   DEPENDS
-    tit::base
     doctest::doctest
 )
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,14 +6,15 @@
   "dependencies": [
     "boost-core",
     "boost-container",
-    "boost-stacktrace",
+    {
+      "name": "boost-stacktrace",
+      "default-features": false
+    },
     "doctest",
     "gcem",
-    "hdf5",
     "highway",
     "metis",
     "mimalloc",
-    "nanobench",
     "tbb"
   ],
   "overrides": [{ "name": "tbb", "version": "2021.13.0" }]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tit",
   "version-string": "0.1.0",
+  "builtin-baseline": "9d163f0612f75a49133cfd051f0ed997a24602d5",
   "dependencies": [
     "boost-core",
     "boost-container",
@@ -14,5 +15,6 @@
     "mimalloc",
     "nanobench",
     "tbb"
-  ]
+  ],
+  "overrides": [{ "name": "tbb", "version": "2021.13.0" }]
 }


### PR DESCRIPTION
- [x] Removed the unused `vcpkg` packages.
- [x] Removed the unneeded default features for the actually used packages.
- [x] OneTBB is now set to a fixed version "2021.13.0", since the latest version cannot compile on macOS.
- [x] Meta target `tit::base` was removed, all the packages are now configured directly.
- [x] Cleaned-up the CMake scripts.