### PR TITLE
Skeleton for the backend.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(
   CONFIG REQUIRED
   COMPONENTS core container stacktrace_addr2line
 )
+find_package(Crow CONFIG REQUIRED)
 find_package(doctest CONFIG REQUIRED)
 find_package(gcem CONFIG REQUIRED)
 find_package(hwy CONFIG REQUIRED)

--- a/source/tit/core/sys_utils.hpp
+++ b/source/tit/core/sys_utils.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <typeinfo>
@@ -43,6 +44,11 @@ void fast_exit(ExitCode exit_code) noexcept;
 
 /// Execute a system command. Fail if the command fails.
 void checked_system(const char* command) noexcept;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Path to the current executable.
+auto exe_path() -> std::filesystem::path;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/titback/CMakeLists.txt
+++ b/source/titback/CMakeLists.txt
@@ -3,9 +3,16 @@
 # See /LICENSE.md for license information. SPDX-License-Identifier: MIT
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-add_subdirectory("tit")
-add_subdirectory("titback")
-add_subdirectory("titfront")
-add_subdirectory("titwcsph")
+add_tit_executable(
+  NAME
+    titback
+  DESTINATION
+    bin
+  SOURCES
+    "backend.cpp"
+  DEPENDS
+    tit::core
+    Crow::Crow
+)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/titback/README.md
+++ b/source/titback/README.md
@@ -1,0 +1,3 @@
+# `titback`
+
+This executable contains application backend.

--- a/source/titback/backend.cpp
+++ b/source/titback/backend.cpp
@@ -1,0 +1,57 @@
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ *\
+ * Part of the Tit Solver project, under the MIT License.
+ * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
+\* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#include <filesystem>
+#include <string>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#include <crow/app.h>
+#include <crow/http_request.h>
+#include <crow/http_response.h>
+#pragma GCC diagnostic pop
+
+#include "tit/core/main_func.hpp"
+#include "tit/core/sys_utils.hpp"
+
+namespace tit::back {
+namespace {
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+auto run_backend(CmdArgs /*args*/) -> int {
+  const auto exe_dir = exe_path().parent_path();
+  const auto root_dir = exe_dir.parent_path();
+
+  crow::SimpleApp app;
+  CROW_ROUTE(app, "/")
+  ([&root_dir](const crow::request& /*request*/, crow::response& response) {
+    const auto index_html = root_dir / "frontend" / "index.html";
+    response.set_static_file_info_unsafe(index_html.native());
+    response.end();
+  });
+  CROW_ROUTE(app, "/<path>")
+  ([&root_dir](const crow::request& /*request*/,
+               crow::response& response,
+               const std::filesystem::path& file_name) {
+    auto file_path = root_dir / "frontend" / file_name;
+    if (std::filesystem::is_directory(file_path)) {
+      file_path /= "index.html";
+    }
+    response.set_static_file_info_unsafe(file_path.native());
+    response.end();
+  });
+
+  app.port(18080).run();
+
+  return 0;
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace
+} // namespace tit::back
+
+TIT_IMPLEMENT_MAIN(back::run_backend)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
       "name": "boost-stacktrace",
       "default-features": false
     },
+    "crow",
     "doctest",
     "gcem",
     "highway",


### PR DESCRIPTION
This PR sets-up a very basic backend: a HTTP server that can deliver the static frontend files.

- Implementation is very basic, since I do not know yet what we want or need.
- No tests so far. It is not easy to setup even the basic test. I do not want to introduce some garbage testing just for the coverage.
- On macOS there is a problem that once the executable is recompiled, macOS asks for the networking permissions. Just asks, everything is allowed, unless explicitly banned. One of the workarounds for this may be to move the implementation into a `.dylib` and have a bare exeutable that invokes `main` on that `.dylib`. Maybe there is a better workaround for it. 