### PR TITLE
Clean-up error handling.

### DIFF
--- a/source/tit/core/checks.cpp
+++ b/source/tit/core/checks.cpp
@@ -17,7 +17,7 @@ namespace tit::impl {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [[noreturn]]
-void handle_check_failure( // NOLINT(*-exception-escape)
+void report_check_failure( // NOLINT(*-exception-escape)
     std::string_view expression,
     std::string_view message,
     std::source_location location) noexcept {

--- a/source/tit/core/checks.hpp
+++ b/source/tit/core/checks.hpp
@@ -10,29 +10,22 @@
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Fail with the given message.
-///
-/// Use this macro to abort the entire process due a failure in the internal
-/// logic with in cases, when the actual check is done elsewhere, (e.g.,
-/// when translating a library error code to a user-friendly message).
-#define TIT_FAIL(message) tit::impl::handle_check_failure("TIT_FAIL()", message)
+/// Should we enable assertions? By default, we enable them in debug mode.
+#if !defined(TIT_ENABLE_ASSERTS) && !defined(NDEBUG)
+#define TIT_ENABLE_ASSERTS
+#endif
 
-/// Check that the given expression holds.
+/// Check that the given expression holds (if assertions are enabled).
 ///
-/// Do not use this macro for user input, but just to check the internal logic.
-/// If the expression does not hold, the entire process is aborted (in constant
-/// evaluation context, compilation is aborted).
-#define TIT_ENSURE(expr, message) tit::impl::run_check((expr), (#expr), message)
-
-/// Check that the given expression holds (in debug mode).
+/// If the expression does not hold, abort the entire process (or abort the
+/// compilation, if the expression is evaluated in `constexpr` context).
 ///
-/// Do not use this macro for user input, but just to check the internal logic.
-/// If the expression does not hold, the entire process is aborted (in constant
-/// evaluation context, compilation is aborted).
-#ifdef NDEBUG
-#define TIT_ASSERT(expr, message) static_cast<void>(expr)
+/// Use this macro to check the internal logic, do not use it for to check the
+/// status of any operation (in such case, use `TIT_THROW` instead).
+#ifdef TIT_ENABLE_ASSERTS
+#define TIT_ASSERT(expr, message) tit::impl::check((expr), (#expr), message)
 #else
-#define TIT_ASSERT(expr, message) TIT_ENSURE((expr), (message))
+#define TIT_ASSERT(expr, message) static_cast<void>(expr)
 #endif
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -40,18 +33,16 @@
 namespace tit::impl {
 
 [[noreturn]]
-void handle_check_failure(
-    std::string_view expression,
-    std::string_view message,
-    std::source_location location = std::source_location::current()) noexcept;
+void report_check_failure(std::string_view expression,
+                          std::string_view message,
+                          std::source_location location) noexcept;
 
-constexpr void run_check(
+constexpr void check(
     bool condition,
     std::string_view expression,
     std::string_view message,
     std::source_location location = std::source_location::current()) noexcept {
-  if (condition) return; // Gracefully return if check passes.
-  handle_check_failure(expression, message, location);
+  if (!condition) report_check_failure(expression, message, location);
 }
 
 } // namespace tit::impl

--- a/source/tit/core/exception.cpp
+++ b/source/tit/core/exception.cpp
@@ -71,7 +71,7 @@ TerminateHandler::TerminateHandler() noexcept
 TerminateHandler::~TerminateHandler() noexcept {
   // Restore the previous terminate handler.
   const auto current_handler = std::set_terminate(prev_handler_);
-  TIT_ENSURE(current_handler == handle_terminate_,
+  TIT_ASSERT(current_handler == handle_terminate_,
              "Terminate handler was not registered previously!");
 }
 

--- a/source/tit/core/exception.hpp
+++ b/source/tit/core/exception.hpp
@@ -88,8 +88,10 @@ private:
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-} // namespace tit
-
 /// Throw an exception.
 #define TIT_THROW(message, ...)                                                \
   throw tit::Exception(std::format((message) __VA_OPT__(, __VA_ARGS__)))
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+} // namespace tit

--- a/source/tit/core/main_func.cpp
+++ b/source/tit/core/main_func.cpp
@@ -20,11 +20,9 @@ namespace tit {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 auto run_main(int argc, char** argv, const MainFunc& main_func) -> int {
-  // Setup signal handler.
-  const FatalSignalHandler handler{};
-
-  // Setup terminate handler.
+  // Setup error handlers.
   const TerminateHandler terminate_handler{};
+  const FatalSignalHandler signal_handler{};
 
   // Enable statistics.
   if (get_env_bool("TIT_ENABLE_STATS", false)) Stats::enable();
@@ -36,9 +34,9 @@ auto run_main(int argc, char** argv, const MainFunc& main_func) -> int {
   par::set_num_threads(get_env_uint("TIT_NUM_THREADS", 8));
 
   // Run the main function.
-  TIT_ENSURE(main_func != nullptr, "Main function must be specified!");
-  TIT_ENSURE(argc > 0, "Invalid number of command line arguments!");
-  TIT_ENSURE(argv != nullptr, "Invalid command line arguments!");
+  TIT_ASSERT(main_func != nullptr, "Main function must be specified!");
+  TIT_ASSERT(argc > 0, "Invalid number of command line arguments!");
+  TIT_ASSERT(argv != nullptr, "Invalid command line arguments!");
   return main_func({const_cast<const char**>(argv), static_cast<size_t>(argc)});
 }
 

--- a/source/tit/core/par/memory_pool.hpp
+++ b/source/tit/core/par/memory_pool.hpp
@@ -17,6 +17,7 @@
 #include <oneapi/tbb/memory_pool.h>
 
 #include "tit/core/checks.hpp"
+#include "tit/core/exception.hpp"
 
 namespace tit::par {
 
@@ -35,7 +36,9 @@ public:
   auto create(Args&&... args) -> Val* {
     TIT_ASSERT(pool_ != nullptr, "Memory pool was moved away!");
     auto* const ptr = static_cast<Val*>(pool_->malloc(sizeof(Val)));
-    TIT_ENSURE(ptr != nullptr, "Memory allocation failed!");
+    if (ptr == nullptr) {
+      TIT_THROW("Memory pool failed to allocate {} bytes.", sizeof(Val));
+    }
     return std::construct_at(ptr, std::forward<Args>(args)...);
   }
 

--- a/source/tit/core/par/thread.hpp
+++ b/source/tit/core/par/thread.hpp
@@ -52,7 +52,7 @@ concept range =
 struct ForEach {
   template<basic_range Range,
            std::regular_invocable<std::ranges::range_reference_t<Range&&>> Func>
-  static void operator()(Range&& range, Func func) {
+  void operator()(Range&& range, Func func) const {
     /// @todo Replace with `tbb::parallel_for_each` when it supports ranges.
     TIT_ASSUME_UNIVERSAL(Range, range);
     tbb::parallel_for(tbb::blocked_range{std::begin(range), std::end(range)},
@@ -69,7 +69,7 @@ inline constexpr ForEach for_each{};
 struct StaticForEach {
   template<basic_range Range,
            std::invocable<size_t, std::ranges::range_reference_t<Range&&>> Func>
-  static void operator()(Range&& range, Func func) {
+  void operator()(Range&& range, Func func) const {
     TIT_ASSUME_UNIVERSAL(Range, range);
     const auto thread_count = num_threads();
     auto block_first = [quotient = std::size(range) / thread_count,
@@ -95,7 +95,7 @@ struct StaticForEach {
            std::invocable<size_t,
                           std::ranges::range_reference_t<
                               std::ranges::join_view<Range>>> Func>
-  static void operator()(std::ranges::join_view<Range> join_view, Func func) {
+  void operator()(std::ranges::join_view<Range> join_view, Func func) const {
     StaticForEach{}( //
         std::move(join_view).base(),
         [&func](size_t thread_index, const auto& range) {
@@ -115,7 +115,7 @@ struct BlockForEach {
   template<range Range,
            std::invocable<std::ranges::range_reference_t<
                std::ranges::range_value_t<Range>>> Func>
-  static void operator()(Range&& range, Func func) {
+  void operator()(Range&& range, Func func) const {
     TIT_ASSUME_UNIVERSAL(Range, range);
     for (auto chunk : std::views::chunk(range, num_threads())) {
       for_each(std::move(chunk),
@@ -138,7 +138,7 @@ struct CopyIf {
            std::indirect_unary_predicate<
                std::projected<std::ranges::iterator_t<Range>, Proj>> Pred>
     requires std::indirectly_copyable<std::ranges::iterator_t<Range>, OutIter>
-  static auto operator()(Range&& range, OutIter out, Pred pred, Proj proj = {})
+  auto operator()(Range&& range, OutIter out, Pred pred, Proj proj = {}) const
       -> OutIter {
     TIT_ASSUME_UNIVERSAL(Range, range);
     ssize_t out_index = 0;
@@ -167,7 +167,7 @@ struct Transform final {
                  std::indirect_result_t<
                      Func&,
                      std::projected<std::ranges::iterator_t<Range>, Proj>>>
-  static auto operator()(Range&& range, OutIter out, Func func, Proj proj = {})
+  auto operator()(Range&& range, OutIter out, Func func, Proj proj = {}) const
       -> OutIter {
     TIT_ASSUME_UNIVERSAL(Range, range);
     const auto out_end = std::next(out, std::size(range));

--- a/source/tit/core/signal.hpp
+++ b/source/tit/core/signal.hpp
@@ -20,16 +20,8 @@ namespace tit {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Signal action entry.
-using sigaction_t = struct sigaction;
-
-/// Set signal action.
-void checked_sigaction(int signal_number,
-                       const sigaction_t* action,
-                       sigaction_t* prev_action = nullptr) noexcept;
-
 /// Raise a signal.
-void checked_raise(int signal_number) noexcept;
+void checked_raise(int signal_number);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -69,7 +61,7 @@ protected:
 
 private:
 
-  std::vector<std::pair<int, sigaction_t>> prev_actions_;
+  std::vector<std::pair<int, struct sigaction>> prev_actions_;
 
   static std::vector<SignalHandler*> handlers_;
   static void handle_signal_(int signal_number) noexcept;

--- a/source/tit/core/sys_utils.hpp
+++ b/source/tit/core/sys_utils.hpp
@@ -22,7 +22,7 @@ namespace tit {
 using atexit_callback_t = void (*)();
 
 /// Register a function to be called at exit.
-void checked_atexit(atexit_callback_t callback) noexcept;
+void checked_atexit(atexit_callback_t callback);
 
 /// Exit code.
 enum class ExitCode : uint8_t {
@@ -43,7 +43,7 @@ void fast_exit(ExitCode exit_code) noexcept;
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Execute a system command. Fail if the command fails.
-void checked_system(const char* command) noexcept;
+void checked_system(const char* command);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -59,7 +59,7 @@ enum class TTY : uint8_t {
 };
 
 /// Query terminal width.
-auto tty_width(TTY tty) noexcept -> std::optional<size_t>;
+auto tty_width(TTY tty) -> std::optional<size_t>;
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/tit/core/utils.hpp
+++ b/source/tit/core/utils.hpp
@@ -68,6 +68,12 @@ constexpr auto in_range(T x,
   return a <= x && x <= b;
 }
 
+/// Check that the value is equal to any of the given values.
+template<class T, std::same_as<T>... Us>
+constexpr auto is_any_of(T x, Us... us) noexcept -> bool {
+  return (... || (x == us));
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Array type that is deduced from the given argument.

--- a/source/tit/sph/particle_mesh.hpp
+++ b/source/tit/sph/particle_mesh.hpp
@@ -17,6 +17,7 @@
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
 #include "tit/core/containers/multivector.hpp"
+#include "tit/core/exception.hpp"
 #include "tit/core/missing.hpp" // IWYU pragma: keep
 #include "tit/core/par.hpp"
 #include "tit/core/profiler.hpp"
@@ -199,8 +200,10 @@ private:
     // Initialize the partitioning.
     const auto num_threads = par::num_threads();
     const auto num_parts = num_levels * num_threads + 1;
-    TIT_ENSURE(num_parts <= std::numeric_limits<PartIndex>::max(),
-               "Number of parts is too large!");
+    if (auto max_num_parts = std::numeric_limits<PartIndex>::max();
+        num_parts >= max_num_parts) {
+      TIT_THROW("Number of parts exceeded the limit of {}.", max_num_parts);
+    }
     const auto parts = parinfo[particles];
     std::ranges::fill(parts, PartVec(static_cast<PartIndex>(num_parts - 1)));
 

--- a/tests/tit/core/env.cpp
+++ b/tests/tit/core/env.cpp
@@ -3,6 +3,7 @@
  * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
 \* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#define TIT_ENABLE_ASSERTS
 #include "tit/core/checks.hpp"
 #include "tit/core/env.hpp"
 #include "tit/core/main_func.hpp"
@@ -14,39 +15,39 @@ namespace {
 
 auto run_test(CmdArgs /*args*/) -> int {
   // Test string variables.
-  TIT_ENSURE(get_env("PATH").has_value(), "");
-  TIT_ENSURE(!get_env("DOES_NOT_EXIST").has_value(), "");
+  TIT_ASSERT(get_env("PATH").has_value(), "Test failed!");
+  TIT_ASSERT(!get_env("DOES_NOT_EXIST").has_value(), "Test failed!");
 
   // Test integer variables.
-  TIT_ENSURE(get_env_int("TEST_ZERO") == 0, "");
-  TIT_ENSURE(get_env_int("TEST_INT") == 123, "");
-  TIT_ENSURE(get_env_int("TEST_INT", 456) == 123, "");
-  TIT_ENSURE(get_env_int("TEST_NEGATIVE") == -456, "");
-  TIT_ENSURE(!get_env_int("DOES_NOT_EXIST").has_value(), "");
-  TIT_ENSURE(get_env_int("DOES_NOT_EXIST", 456) == 456, "");
+  TIT_ASSERT(get_env_int("TEST_ZERO") == 0, "Test failed!");
+  TIT_ASSERT(get_env_int("TEST_INT") == 123, "Test failed!");
+  TIT_ASSERT(get_env_int("TEST_INT", 456) == 123, "Test failed!");
+  TIT_ASSERT(get_env_int("TEST_NEGATIVE") == -456, "Test failed!");
+  TIT_ASSERT(!get_env_int("DOES_NOT_EXIST").has_value(), "Test failed!");
+  TIT_ASSERT(get_env_int("DOES_NOT_EXIST", 456) == 456, "Test failed!");
 
   // Test unsigned integer variables.
-  TIT_ENSURE(get_env_uint("TEST_ZERO") == 0, "");
-  TIT_ENSURE(get_env_uint("TEST_INT") == 123, "");
-  TIT_ENSURE(get_env_uint("TEST_INT", 456) == 123, "");
-  TIT_ENSURE(!get_env_uint("DOES_NOT_EXIST").has_value(), "");
-  TIT_ENSURE(get_env_uint("DOES_NOT_EXIST", 456) == 456, "");
+  TIT_ASSERT(get_env_uint("TEST_ZERO") == 0, "Test failed!");
+  TIT_ASSERT(get_env_uint("TEST_INT") == 123, "Test failed!");
+  TIT_ASSERT(get_env_uint("TEST_INT", 456) == 123, "Test failed!");
+  TIT_ASSERT(!get_env_uint("DOES_NOT_EXIST").has_value(), "Test failed!");
+  TIT_ASSERT(get_env_uint("DOES_NOT_EXIST", 456) == 456, "Test failed!");
 
   // Test floating-point variables.
-  TIT_ENSURE(get_env_float("TEST_INT") == 123.0, "");
-  TIT_ENSURE(get_env_float("TEST_FLOAT") == 123.456, "");
-  TIT_ENSURE(!get_env_float("DOES_NOT_EXIST").has_value(), "");
-  TIT_ENSURE(get_env_float("DOES_NOT_EXIST", 789.0) == 789.0, "");
+  TIT_ASSERT(get_env_float("TEST_INT") == 123.0, "Test failed!");
+  TIT_ASSERT(get_env_float("TEST_FLOAT") == 123.456, "Test failed!");
+  TIT_ASSERT(!get_env_float("DOES_NOT_EXIST").has_value(), "Test failed!");
+  TIT_ASSERT(get_env_float("DOES_NOT_EXIST", 789.0) == 789.0, "Test failed!");
 
   // Test boolean variables.
-  TIT_ENSURE(get_env_bool("TEST_TRUE").value_or(false), "");
-  TIT_ENSURE(!get_env_bool("TEST_FALSE").value_or(false), "");
-  TIT_ENSURE(!get_env_bool("TEST_FALSE", true), "");
-  TIT_ENSURE(get_env_bool("TEST_INT").value_or(false), "");
-  TIT_ENSURE(get_env_bool("TEST_INT", false), "");
-  TIT_ENSURE(!get_env_bool("TEST_ZERO").value_or(false), "");
-  TIT_ENSURE(!get_env_bool("DOES_NOT_EXIST").has_value(), "");
-  TIT_ENSURE(get_env_bool("DOES_NOT_EXIST", true), "");
+  TIT_ASSERT(get_env_bool("TEST_TRUE").value_or(false), "Test failed!");
+  TIT_ASSERT(!get_env_bool("TEST_FALSE").value_or(false), "Test failed!");
+  TIT_ASSERT(!get_env_bool("TEST_FALSE", true), "Test failed!");
+  TIT_ASSERT(get_env_bool("TEST_INT").value_or(false), "Test failed!");
+  TIT_ASSERT(get_env_bool("TEST_INT", false), "Test failed!");
+  TIT_ASSERT(!get_env_bool("TEST_ZERO").value_or(false), "Test failed!");
+  TIT_ASSERT(!get_env_bool("DOES_NOT_EXIST").has_value(), "Test failed!");
+  TIT_ASSERT(get_env_bool("DOES_NOT_EXIST", true), "Test failed!");
 
   return 0;
 }

--- a/tests/tit/core/failed_check.cpp
+++ b/tests/tit/core/failed_check.cpp
@@ -3,6 +3,7 @@
  * See /LICENSE.md for license information. SPDX-License-Identifier: MIT
 \* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
+#define TIT_ENABLE_ASSERTS
 #include "tit/core/checks.hpp"
 #include "tit/core/io.hpp"
 #include "tit/core/main_func.hpp"
@@ -16,7 +17,7 @@ namespace {
 void func_3() {
   eprintln("func_3");
   eprintln("Checking how floating point arithmetic works...");
-  TIT_ENSURE(0.1 + 0.2 == 0.3, "Right?!");
+  TIT_ASSERT(0.1 + 0.2 == 0.3, "Right?!");
 }
 
 [[gnu::noinline]]


### PR DESCRIPTION
- `TIT_ENSURE` macro gets removed, `TIT_THROW` should be used instead.
- A few other error-related clean-ups.
- I've also had to replace some `static operator()` with regular ones due to random failures in clang-tidy.