### PR TITLE
Use zero-terminated string view instead of `const char*`.

### DIFF
--- a/source/tit/core/sys/utils.cpp
+++ b/source/tit/core/sys/utils.cpp
@@ -25,6 +25,7 @@
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
 #include "tit/core/exception.hpp"
+#include "tit/core/str_utils.hpp"
 #include "tit/core/sys/utils.hpp"
 
 #ifdef TIT_HAVE_GCOV
@@ -69,9 +70,8 @@ auto exe_path() -> std::filesystem::path {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-auto get_env(const char* name) noexcept -> std::optional<std::string_view> {
-  TIT_ASSERT(name != nullptr, "Environment variable name must not be null!");
-  const auto* const value = std::getenv(name); // NOLINT(*-mt-unsafe)
+auto get_env(CStrView name) noexcept -> std::optional<std::string_view> {
+  const auto* const value = std::getenv(name.c_str()); // NOLINT(*-mt-unsafe)
   if (value == nullptr) return std::nullopt;
   return std::string_view{value};
 }
@@ -94,14 +94,14 @@ auto tty_width(TTY tty) -> std::optional<size_t> {
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-auto try_demangle(const char* mangled_name) -> std::optional<std::string> {
-  const boost::core::scoped_demangled_name demangled_name{mangled_name};
+auto try_demangle(CStrView mangled_name) -> std::optional<std::string> {
+  const boost::core::scoped_demangled_name demangled_name{mangled_name.c_str()};
   if (const auto* p = demangled_name.get(); p != nullptr) return p;
   return std::nullopt;
 }
 
-auto maybe_demangle(const char* mangled_name) -> std::string {
-  return try_demangle(mangled_name).value_or(mangled_name);
+auto maybe_demangle(CStrView mangled_name) -> std::string {
+  return try_demangle(mangled_name).value_or(mangled_name.c_str());
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/core/sys/utils.hpp
+++ b/source/tit/core/sys/utils.hpp
@@ -58,13 +58,13 @@ auto tty_width(TTY tty) -> std::optional<size_t>;
 
 /// Get the value of an environment variable.
 /// @{
-auto get_env(const char* name) noexcept -> std::optional<std::string_view>;
+auto get_env(CStrView name) noexcept -> std::optional<std::string_view>;
 template<class Val>
-auto get_env(const char* name) -> std::optional<Val> {
+auto get_env(CStrView name) noexcept -> std::optional<Val> {
   return get_env(name).and_then(str_to<Val>);
 }
 template<class Val>
-auto get_env(const char* name, Val fallback) -> Val {
+auto get_env(CStrView name, Val fallback) noexcept -> Val {
   return get_env<Val>(name).value_or(fallback);
 }
 /// @}
@@ -73,7 +73,7 @@ auto get_env(const char* name, Val fallback) -> Val {
 
 /// Try to demangle a mangled name.
 /// @{
-auto try_demangle(const char* mangled_name) -> std::optional<std::string>;
+auto try_demangle(CStrView mangled_name) -> std::optional<std::string>;
 auto try_demangle_arg_type(const auto& arg) -> std::optional<std::string> {
   return try_demangle(typeid(arg).name());
 }
@@ -86,7 +86,7 @@ auto try_demangle_type() -> std::optional<std::string> {
 /// Try to demangle a mangled name.
 /// If demangling fails, return the original name.
 /// @{
-auto maybe_demangle(const char* mangled_name) -> std::string;
+auto maybe_demangle(CStrView mangled_name) -> std::string;
 auto maybe_demangle_arg_type(const auto& arg) -> std::string {
   return maybe_demangle(typeid(arg).name());
 }

--- a/source/tit/data/sqlite.hpp
+++ b/source/tit/data/sqlite.hpp
@@ -17,6 +17,7 @@
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
+#include "tit/core/str_utils.hpp"
 #include "tit/core/stream.hpp"
 
 struct sqlite3;
@@ -48,7 +49,7 @@ public:
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   /// Execute a SQL statement.
-  void execute(const char* sql) const;
+  void execute(CStrView sql) const;
 
   /// Get the last insert row ID.
   auto last_insert_row_id() const -> RowID;
@@ -247,8 +248,8 @@ public:
 
   /// Open a blob from a database.
   BlobReader(const Database& db,
-             const char* table_name,
-             const char* column_name,
+             CStrView table_name,
+             CStrView column_name,
              RowID row_id);
 
   /// SQLite blob object.
@@ -272,8 +273,8 @@ private:
 
 /// Make a blob reader.
 constexpr auto make_blob_reader(const Database& db,
-                                const char* table_name,
-                                const char* column_name,
+                                CStrView table_name,
+                                CStrView column_name,
                                 RowID row_id) -> InputStreamPtr<byte_t> {
   return std::make_unique<BlobReader>(db, table_name, column_name, row_id);
 }

--- a/source/tit/sph/field.hpp
+++ b/source/tit/sph/field.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <concepts>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -103,7 +104,7 @@ concept field_set = impl::is_field_set_v<FieldSet>;
   public:                                                                      \
                                                                                \
     /** Field name. */                                                         \
-    static constexpr const char* field_name = #name;                           \
+    static constexpr std::string_view field_name = #name;                      \
                                                                                \
     /** Field type. */                                                         \
     template<class Real, size_t Dim>                                           \


### PR DESCRIPTION
This PR introduces a `CStrView`, a counterpart of `std::string_view` designed specifically for zero-terminated strings. 