### PR TITLE
Stream access to storage objects.

### DIFF
--- a/source/tit/core/math.hpp
+++ b/source/tit/core/math.hpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "tit/core/basic_types.hpp"
+#include "tit/core/checks.hpp"
 
 namespace tit {
 
@@ -70,14 +71,23 @@ constexpr auto pow2(Num a) -> Num {
   return a * a;
 }
 
-/// Raise to the unsigned integer power.
-template<unsigned Power, class Num>
-constexpr auto pow(Num a) -> Num {
-  static_assert(Power > 0, "Power must be positive!");
-  if constexpr (Power == 1) return a;
-  else if constexpr (Power % 2 == 0) return pow<Power / 2>(a * a);
-  else return a * pow<Power / 2>(a * a);
+/// Raise to the non-negative integer power.
+/// @{
+template<class Num>
+constexpr auto ipow(Num a, std::integral auto power) -> Num {
+  if constexpr (std::integral<Num> || std::floating_point<Num>) {
+    TIT_ASSERT(power >= 0, "Power must be non-negative!");
+    if (power == 0) return Num{1};
+  } else TIT_ASSERT(power > 0, "Power must be positive!");
+  if (power == 1) return a;
+  if (power % 2 == 0) return ipow(a * a, power / 2);
+  return a * ipow(a * a, power / 2);
 }
+template<std::integral auto Power, class Num>
+constexpr auto pow(Num a) -> Num {
+  return ipow(a, Power);
+}
+/// @}
 
 /// Raise to the floating-point power.
 template<std::floating_point Float>

--- a/source/tit/core/math.test.cpp
+++ b/source/tit/core/math.test.cpp
@@ -67,13 +67,15 @@ TEST_CASE_TEMPLATE("bitwise_equal", Num, NUM_TYPES) {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 TEST_CASE_TEMPLATE("pow", Num, NUM_TYPES) {
+  CHECK(pow<0>(-Num{2}) == +Num{1});
+  CHECK(ipow(-Num{2}, 1) == -Num{2});
   CHECK(pow2(-Num{2}) == +Num{4});
   CHECK(pow<3>(-Num{2}) == -Num{8});
-  CHECK(pow<4>(-Num{2}) == +Num{16});
+  CHECK(ipow(-Num{2}, 4) == +Num{16});
   CHECK(pow<5>(-Num{2}) == -Num{32});
   CHECK(pow<6>(-Num{2}) == +Num{64});
   CHECK(pow<7>(-Num{2}) == -Num{128});
-  CHECK(pow<8>(-Num{2}) == +Num{256});
+  CHECK(ipow(-Num{2}, 8) == +Num{256});
   CHECK(pow<9>(-Num{2}) == -Num{512});
   CHECK(pow(-Num{2}, 10) == Num{1024});
 }

--- a/source/tit/core/stream.hpp
+++ b/source/tit/core/stream.hpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <concepts>
 #include <exception>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <ranges>
@@ -18,6 +19,7 @@
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
+#include "tit/core/containers/boost.hpp"
 #include "tit/core/log.hpp"
 #include "tit/core/utils.hpp"
 
@@ -44,7 +46,72 @@ public:
 /// Abstract input stream pointer.
 template<class Item>
   requires std::is_object_v<Item>
-using InputStreamPtr = std::unique_ptr<InputStream<Item>>;
+class InputStreamPtr final : public std::unique_ptr<InputStream<Item>> {
+public:
+
+  // Inherit constructors and assignment operators.
+  using std::unique_ptr<InputStream<Item>>::unique_ptr;
+  using std::unique_ptr<InputStream<Item>>::operator=;
+
+  /// Iterator type.
+  class Iterator final {
+  public:
+
+    // Required by iterator specification.
+    using value_type = Item;
+    using difference_type = ssize_t;
+
+    /// Construct an iterator.
+    constexpr explicit Iterator(InputStream<Item>* stream = nullptr) noexcept
+        : stream_{stream} {
+      if (stream_ != nullptr) ++(*this);
+    }
+
+    /// Increment the iterator.
+    /// @{
+    constexpr auto operator++() -> Iterator& {
+      TIT_ASSERT(stream_ != nullptr, "Stream is null!");
+      if (stream_->read({&item_, 1}) != 1) stream_ = nullptr;
+      return *this;
+    }
+    constexpr auto operator++(int) -> Iterator {
+      Iterator r{*this};
+      ++(*this);
+      return r;
+    }
+    /// @}
+
+    /// Get the item referenced by the iterator.
+    constexpr auto operator*() const -> const Item& {
+      TIT_ASSERT(stream_ != nullptr, "Stream is null!");
+      return item_;
+    }
+
+    /// Check if the iterator reached the end.
+    friend constexpr auto operator==(Iterator a, Iterator b) noexcept -> bool {
+      return a.stream_ == b.stream_;
+    }
+
+  private:
+
+    InputStream<Item>* stream_;
+    Item item_;
+
+  }; // class Iterator
+
+  /// Iterator pointing to the first stream element.
+  /// Please note that iteration over a stream consumes it.
+  constexpr auto begin() const noexcept -> Iterator {
+    return Iterator{this->get()};
+  }
+
+  /// Iterator pointing to the element after the last stream element.
+  constexpr auto end() const noexcept -> Iterator {
+    static_cast<void>(this);
+    return Iterator{nullptr};
+  }
+
+}; // class InputStreamPtr
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -141,6 +208,40 @@ constexpr auto make_range_input_stream(Items&& items)
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+/// Generator input stream.
+template<class Item, std::invocable<Item&> Generator>
+class GeneratorInputStream final : public InputStream<Item> {
+public:
+
+  /// Construct a generator input stream.
+  constexpr explicit GeneratorInputStream(Generator generator) noexcept
+      : generator_{std::move(generator)} {}
+
+  /// Read the next items from the stream.
+  constexpr auto read(std::span<Item> items) -> size_t override {
+    size_t copied = 0;
+    for (auto& item : items) {
+      if (!std::invoke(generator_, item)) break;
+      ++copied;
+    }
+    return copied;
+  }
+
+private:
+
+  [[no_unique_address]] Generator generator_;
+
+}; // class GeneratorStream
+
+template<class Item, std::invocable<Item&> Generator>
+constexpr auto make_generator_input_stream(Generator generator)
+    -> InputStreamPtr<Item> {
+  using Result = GeneratorInputStream<Item, Generator>;
+  return std::make_unique<Result>(std::move(generator));
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 /// Iterator output stream.
 template<class Item, std::output_iterator<Item> OutIter>
 class IteratorOutputStream final : public OutputStream<Item> {
@@ -185,38 +286,93 @@ constexpr auto make_container_output_stream(Container& container)
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Read the items from the input stream into the container.
-template<class Item, class Container>
-constexpr auto read_from(InputStreamPtr<Item> stream,
-                         Container& container,
-                         size_t chunk_size) -> Container& {
-  TIT_ASSERT(stream != nullptr, "Stream is null!");
-  TIT_ASSERT(chunk_size > 0, "Chunk size must be positive!");
-  while (true) {
-    const auto size = std::size(container);
-    container.resize(size + chunk_size);
-    const auto copied = stream->read(std::span{container}.subspan(size));
-    if (copied < chunk_size) {
-      container.resize(size + copied);
-      break;
+/// Output stream that counts the number of items written.
+template<class Item, std::invocable<size_t> Callback>
+class CountingOutputStream final : public OutputStream<Item> {
+public:
+
+  TIT_NOT_COPYABLE_OR_MOVABLE(CountingOutputStream);
+
+  /// Construct a tracking output stream.
+  explicit CountingOutputStream(OutputStreamPtr<Item> stream, Callback callback)
+      : stream_{std::move(stream)}, callback_{std::move(callback)} {}
+
+  /// Close the stream.
+  ~CountingOutputStream() override {
+    try {
+      callback_(written_);
+    } catch (const std::exception& e) {
+      TIT_ERROR("Failed to call on_finish: {}", e.what());
     }
   }
-  return container;
+
+  /// Write the next items to the stream.
+  void write(std::span<const Item> items) override {
+    stream_->write(items);
+    written_ += items.size();
+  }
+
+  /// Flush the stream.
+  void flush() override {
+    stream_->flush();
+  }
+
+private:
+
+  OutputStreamPtr<Item> stream_;
+  size_t written_ = 0;
+  [[no_unique_address]] Callback callback_;
+
+}; // class CountingOutputStream
+
+/// Make a tracking output stream.
+template<class Item, class Callback>
+auto make_counting_output_stream(OutputStreamPtr<Item> stream,
+                                 Callback callback) -> OutputStreamPtr<Item> {
+  using Result = CountingOutputStream<Item, Callback>;
+  return make_flushable<Result>(std::move(stream), std::move(callback));
 }
 
-/// Write the items to the output stream.
-template<std::ranges::input_range Items>
-constexpr void write_to(
-    OutputStreamPtr<std::ranges::range_value_t<Items>> stream,
-    Items&& items) {
-  TIT_ASSUME_UNIVERSAL(Items, items);
-  if constexpr (std::ranges::sized_range<Items> &&
-                std::ranges::contiguous_range<Items>) {
-    stream->write(
-        std::span{std::ranges::data(items), std::ranges::size(items)});
-  } else {
-    for (const auto& item : items) stream->write({&item, 1});
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Input stream transformer.
+template<class SourceItem, std::invocable<SourceItem&> Proj>
+class ProjectedInputStream final :
+    public InputStream<std::invoke_result_t<Proj&, SourceItem&>> {
+public:
+
+  /// Item type.
+  using Item = std::invoke_result_t<Proj&, SourceItem&>;
+
+  /// Construct a transform input stream.
+  constexpr explicit ProjectedInputStream(InputStreamPtr<SourceItem> stream,
+                                          Proj proj) noexcept
+      : stream_{std::move(stream)}, proj_{std::move(proj)} {}
+
+  /// Read the next items from the stream.
+  constexpr auto read(std::span<Item> items) -> size_t override {
+    buffer_.resize(items.size());
+    const auto copied = stream_->read(buffer_);
+    std::ranges::transform(buffer_ | std::views::take(copied),
+                           std::begin(items),
+                           proj_);
+    return copied;
   }
+
+private:
+
+  InputStreamPtr<SourceItem> stream_;
+  SmallVector<SourceItem, 4> buffer_;
+  [[no_unique_address]] Proj proj_;
+
+}; // class ProjInputStream
+
+/// Transform an input stream.
+template<class SourceItem, std::invocable<SourceItem&> Proj>
+constexpr auto transform_stream(InputStreamPtr<SourceItem> stream, Proj proj)
+    -> InputStreamPtr<std::invoke_result_t<Proj&, SourceItem&>> {
+  using Result = ProjectedInputStream<SourceItem, Proj>;
+  return std::make_unique<Result>(std::move(stream), std::move(proj));
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/data/storage.cpp
+++ b/source/tit/data/storage.cpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <string_view>
 #include <utility>
-#include <vector>
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
@@ -60,6 +59,7 @@ DataStorage::DataStorage(const std::filesystem::path& path) : db_{path} {
       data_set_id INTEGER NOT NULL,
       name        TEXT NOT NULL,
       type        INTEGER NOT NULL,
+      size        INTEGER,
       data        BLOB,
       FOREIGN KEY (data_set_id) REFERENCES DataSets(id) ON DELETE CASCADE
     ) STRICT;
@@ -107,15 +107,16 @@ auto DataStorage::num_series() const -> size_t {
   return statement.column<size_t>();
 }
 
-auto DataStorage::series_ids() const -> std::vector<DataSeriesID> {
+auto DataStorage::series_ids() const -> InputStreamPtr<DataSeriesID> {
   sqlite::Statement statement{db_, R"SQL(
     SELECT id FROM DataSeries ORDER BY id ASC
   )SQL"};
-  std::vector<DataSeriesID> result{};
-  while (statement.step()) {
-    result.emplace_back(statement.column<sqlite::RowID>());
-  }
-  return result;
+  return make_generator_input_stream<DataSeriesID>(
+      [statement = std::move(statement)](DataSeriesID& out) mutable {
+        if (!statement.step()) return false;
+        out = DataSeriesID{statement.column<sqlite::RowID>()};
+        return true;
+      });
 }
 
 auto DataStorage::last_series_id() const -> DataSeriesID {
@@ -185,17 +186,18 @@ auto DataStorage::series_num_time_steps(DataSeriesID series_id) const
 }
 
 auto DataStorage::series_time_step_ids(DataSeriesID series_id) const
-    -> std::vector<DataTimeStepID> {
+    -> InputStreamPtr<DataTimeStepID> {
   TIT_ASSERT(check_series(series_id), "Invalid series ID!");
   sqlite::Statement statement{db_, R"SQL(
-    SELECT id FROM TimeSteps WHERE series_id = ? ORDER BY id ASC
-  )SQL"};
+        SELECT id FROM TimeSteps WHERE series_id = ? ORDER BY id ASC
+      )SQL"};
   statement.bind(series_id.get());
-  std::vector<DataTimeStepID> result{};
-  while (statement.step()) {
-    result.emplace_back(statement.column<sqlite::RowID>());
-  }
-  return result;
+  return make_generator_input_stream<DataTimeStepID>(
+      [statement = std::move(statement)](DataTimeStepID& out) mutable {
+        if (!statement.step()) return false;
+        out = DataTimeStepID{statement.column<sqlite::RowID>()};
+        return true;
+      });
 }
 
 auto DataStorage::series_last_time_step_id(DataSeriesID series_id) const
@@ -319,18 +321,20 @@ auto DataStorage::dataset_num_arrays(DataSetID dataset_id) const -> size_t {
 }
 
 auto DataStorage::dataset_array_ids(DataSetID dataset_id) const
-    -> std::vector<std::pair<std::string, DataArrayID>> {
+    -> InputStreamPtr<std::pair<std::string, DataArrayID>> {
   TIT_ASSERT(check_dataset(dataset_id), "Invalid data set ID!");
   sqlite::Statement statement{db_, R"SQL(
     SELECT name, id FROM DataArrays WHERE data_set_id = ? ORDER BY id ASC
   )SQL"};
   statement.bind(dataset_id.get());
-  std::vector<std::pair<std::string, DataArrayID>> result{};
-  while (statement.step()) {
-    auto [name, id] = statement.columns<std::string, sqlite::RowID>();
-    result.emplace_back(std::move(name), DataArrayID{id});
-  }
-  return result;
+  return make_generator_input_stream<std::pair<std::string, DataArrayID>>(
+      [statement = std::move(statement)](
+          std::pair<std::string, DataArrayID>& out) mutable {
+        if (!statement.step()) return false;
+        auto [name, id] = statement.columns<std::string, sqlite::RowID>();
+        out = {std::move(name), DataArrayID{id}};
+        return true;
+      });
 }
 
 auto DataStorage::find_array_id(DataSetID dataset_id,
@@ -395,11 +399,30 @@ auto DataStorage::array_type(DataArrayID array_id) const -> DataType {
   return DataType{statement.column<uint32_t>()};
 }
 
+auto DataStorage::array_size(DataArrayID array_id) const -> size_t {
+  TIT_ASSERT(check_array(array_id), "Invalid data array ID!");
+  sqlite::Statement statement{db_, R"SQL(
+    SELECT size FROM DataArrays WHERE id = ?
+  )SQL"};
+  statement.bind(array_id.get());
+  if (!statement.step()) TIT_THROW("Unable to get data array size!");
+  return statement.column<size_t>();
+}
+
 auto DataStorage::array_data_open_write(DataArrayID array_id)
     -> OutputStreamPtr<byte_t> {
   TIT_ASSERT(check_array(array_id), "Invalid data array ID!");
-  return zstd::make_stream_compressor(
-      sqlite::make_blob_writer(db_, "DataArrays", "data", array_id.get()));
+  return make_counting_output_stream(
+      zstd::make_stream_compressor(
+          sqlite::make_blob_writer(db_, "DataArrays", "data", array_id.get())),
+      [this, array_id](size_t copied_bytes) {
+        const auto byte_width = array_type(array_id).width();
+        TIT_ASSERT(copied_bytes % byte_width == 0, "Truncated data!");
+        sqlite::Statement statement{db_, R"SQL(
+          UPDATE DataArrays SET size = ? WHERE id = ?
+        )SQL"};
+        statement.run(copied_bytes / byte_width, array_id.get());
+      });
 }
 
 auto DataStorage::array_data_open_read(DataArrayID array_id) const
@@ -407,15 +430,6 @@ auto DataStorage::array_data_open_read(DataArrayID array_id) const
   TIT_ASSERT(check_array(array_id), "Invalid data array ID!");
   return zstd::make_stream_decompressor(
       sqlite::make_blob_reader(db_, "DataArrays", "data", array_id.get()));
-}
-
-auto DataStorage::array_data(DataArrayID array_id) const
-    -> std::vector<byte_t> {
-  std::vector<byte_t> result;
-  read_from(array_data_open_read(array_id),
-            result,
-            /*chunk_size=*/(64 * 1024UZ));
-  return result;
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/tit/data/storage.hpp
+++ b/source/tit/data/storage.hpp
@@ -14,7 +14,6 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 #include "tit/core/basic_types.hpp"
 #include "tit/core/checks.hpp"
@@ -61,6 +60,9 @@ template<data_storage Storage>
 class DataArrayView final {
 public:
 
+  /// Construct a null data array view.
+  constexpr DataArrayView() noexcept = default;
+
   /// Construct a data array view.
   constexpr explicit DataArrayView(Storage& storage, DataArrayID array_id)
       : storage_{&storage}, array_id_{array_id} {
@@ -69,13 +71,14 @@ public:
 
   /// Get the data storage.
   constexpr auto storage() const noexcept -> Storage& {
-    TIT_ASSERT(storage_ != nullptr, "Data storage was not set!");
+    TIT_ASSERT(storage_ != nullptr, "Storage is null!");
     return *storage_;
   }
 
   /// Get the data array ID.
   /// @{
   constexpr auto id() const noexcept -> DataArrayID {
+    TIT_ASSERT(array_id_.get() != 0, "Array ID is null!");
     return array_id_;
   }
   constexpr explicit(false) operator DataArrayID() const noexcept {
@@ -95,21 +98,41 @@ public:
     return storage().array_type(array_id_);
   }
 
-  /// Get the data of the data array.
+  /// Get the size of a data array (in elements).
+  auto size() const -> size_t {
+    return storage().array_size(array_id_);
+  }
+
+  /// Open an output stream to write the data.
   /// @{
-  auto data() const -> std::vector<byte_t> {
-    return storage().array_data(array_id_);
+  auto open_write() const -> OutputStreamPtr<byte_t>
+    requires (!std::is_const_v<Storage>)
+  {
+    return storage().array_data_open_write(array_id_);
   }
   template<known_type_of Val>
-  auto data() const -> std::vector<Val> {
-    return storage().template array_data<Val>(array_id_);
+  auto open_write() const -> OutputStreamPtr<Val>
+    requires (!std::is_const_v<Storage>)
+  {
+    return storage().template array_data_open_write<Val>(array_id_);
+  }
+  /// @}
+
+  /// Open an input stream to read the data.
+  /// @{
+  auto open_read() const -> InputStreamPtr<byte_t> {
+    return storage().array_data_open_read(array_id_);
+  }
+  template<known_type_of Val>
+  auto open_read() const -> InputStreamPtr<Val> {
+    return storage().template array_data_open_read<Val>(array_id_);
   }
   /// @}
 
 private:
 
-  Storage* storage_;
-  DataArrayID array_id_;
+  Storage* storage_ = nullptr;
+  DataArrayID array_id_{0};
 
 }; // class DataArrayView
 
@@ -120,6 +143,9 @@ template<data_storage Storage>
 class DataSetView final {
 public:
 
+  /// Construct a null data set view.
+  constexpr DataSetView() noexcept = default;
+
   /// Construct a dataset view.
   constexpr explicit DataSetView(Storage& storage, DataSetID dataset_id)
       : storage_{&storage}, dataset_id_{dataset_id} {
@@ -128,13 +154,14 @@ public:
 
   /// Get the data storage.
   constexpr auto storage() const noexcept -> Storage& {
-    TIT_ASSERT(storage_ != nullptr, "Data storage was not set!");
+    TIT_ASSERT(storage_ != nullptr, "Storage is null!");
     return *storage_;
   }
 
   /// Get the dataset ID.
   /// @{
   constexpr auto id() const noexcept -> DataSetID {
+    TIT_ASSERT(dataset_id_.get() != 0, "Data set ID is null!");
     return dataset_id_;
   }
   constexpr explicit(false) operator DataSetID() const noexcept {
@@ -177,8 +204,8 @@ public:
 
 private:
 
-  Storage* storage_;
-  DataSetID dataset_id_;
+  Storage* storage_ = nullptr;
+  DataSetID dataset_id_{0};
 
 }; // class DataSetView
 
@@ -189,6 +216,9 @@ template<data_storage Storage>
 class DataTimeStepView final {
 public:
 
+  /// Construct a null data time step view.
+  constexpr DataTimeStepView() noexcept = default;
+
   /// Construct a data time step view.
   constexpr explicit DataTimeStepView(Storage& storage,
                                       DataTimeStepID time_step_id)
@@ -198,13 +228,14 @@ public:
 
   /// Get the data storage.
   constexpr auto storage() const noexcept -> Storage& {
-    TIT_ASSERT(storage_ != nullptr, "Data storage was not set!");
+    TIT_ASSERT(storage_ != nullptr, "Storage is null!");
     return *storage_;
   }
 
   /// Get the data time step ID.
   /// @{
   constexpr auto id() const noexcept -> DataTimeStepID {
+    TIT_ASSERT(time_step_id_.get() != 0, "Time step ID is null!");
     return time_step_id_;
   }
   constexpr explicit(false) operator DataTimeStepID() const noexcept {
@@ -236,8 +267,8 @@ public:
 
 private:
 
-  Storage* storage_;
-  DataTimeStepID time_step_id_;
+  Storage* storage_ = nullptr;
+  DataTimeStepID time_step_id_{0};
 
 }; // class DataTimeStepView
 
@@ -248,6 +279,9 @@ template<data_storage Storage>
 class DataSeriesView final {
 public:
 
+  /// Construct a null data series view.
+  constexpr DataSeriesView() noexcept = default;
+
   /// Construct a data series view.
   constexpr explicit DataSeriesView(Storage& storage, DataSeriesID series_id)
       : storage_{&storage}, series_id_{series_id} {
@@ -256,13 +290,14 @@ public:
 
   /// Get the data storage.
   constexpr auto storage() const noexcept -> Storage& {
-    TIT_ASSERT(storage_ != nullptr, "Data storage was not set!");
+    TIT_ASSERT(storage_ != nullptr, "Storage is null!");
     return *storage_;
   }
 
   /// Get the data series ID.
   /// @{
   constexpr auto id() const noexcept -> DataSeriesID {
+    TIT_ASSERT(series_id_.get() != 0, "Series ID is null!");
     return series_id_;
   }
   constexpr explicit(false) operator DataSeriesID() const noexcept {
@@ -301,14 +336,14 @@ public:
   auto create_time_step(real_t time) const -> DataTimeStepView<Storage>
     requires (!std::is_const_v<Storage>)
   {
-    TIT_ASSERT(storage_ != nullptr, "Data storage was not set!");
+    TIT_ASSERT(storage_ != nullptr, "Storage is null!");
     return storage().create_time_step(series_id_, time);
   }
 
 private:
 
-  Storage* storage_;
-  DataSeriesID series_id_;
+  Storage* storage_ = nullptr;
+  DataSeriesID series_id_{0};
 
 }; // class DataSeriesView
 
@@ -340,11 +375,11 @@ public:
 
   /// Enumerate all data series.
   /// @{
-  auto series_ids() const -> std::vector<DataSeriesID>;
+  auto series_ids() const -> InputStreamPtr<DataSeriesID>;
   auto series(this auto& self) {
-    return self.series_ids() | std::views::transform([&self](DataSeriesID id) {
-             return DataSeriesView{self, id};
-           });
+    return transform_stream(self.series_ids(), [&self](DataSeriesID id) {
+      return DataSeriesView{self, id};
+    });
   }
   /// @}
 
@@ -382,12 +417,11 @@ public:
   /// Enumerate all time steps in the series.
   /// @{
   auto series_time_step_ids(DataSeriesID series_id) const
-      -> std::vector<DataTimeStepID>;
+      -> InputStreamPtr<DataTimeStepID>;
   auto series_time_steps(this auto& self, DataSeriesID series_id) {
-    return self.series_time_step_ids(series_id) |
-           std::views::transform([&self](DataTimeStepID id) {
-             return DataTimeStepView{self, id};
-           });
+    return transform_stream(
+        self.series_time_step_ids(series_id),
+        [&self](DataTimeStepID id) { return DataTimeStepView{self, id}; });
   }
   /// @}
 
@@ -447,13 +481,14 @@ public:
   /// Enumerate all data arrays in the dataset.
   /// @{
   auto dataset_array_ids(DataSetID dataset_id) const
-      -> std::vector<std::pair<std::string, DataArrayID>>;
+      -> InputStreamPtr<std::pair<std::string, DataArrayID>>;
   auto dataset_arrays(this auto& self, DataSetID dataset_id) {
-    return self.dataset_array_ids(dataset_id) |
-           std::views::transform([&self](auto name_and_id) {
-             auto [name, id] = std::move(name_and_id);
-             return std::pair{std::move(name), DataArrayView{self, id}};
-           });
+    return transform_stream( //
+        self.dataset_array_ids(dataset_id),
+        [&self](auto name_and_id) {
+          auto [name, id] = std::move(name_and_id);
+          return std::pair{std::move(name), DataArrayView{self, id}};
+        });
   }
   /// @}
 
@@ -486,7 +521,7 @@ public:
     TIT_ASSUME_UNIVERSAL(Vals, vals);
     using Val = std::ranges::range_value_t<Vals>;
     const auto array_id = create_array_id(dataset_id, name, type_of<Val>);
-    write_to(array_data_open_write<Val>(array_id), vals);
+    array_data_open_write<Val>(array_id)->write(vals);
     return array_id;
   }
   template<class... Args>
@@ -506,10 +541,13 @@ public:
   /// Check if a data array with the given ID exists.
   auto check_array(DataArrayID array_id) const -> bool;
 
-  /// Get the data type of a data array.
+  /// Get the data type of the data array.
   auto array_type(DataArrayID array_id) const -> DataType;
 
-  /// Open an output stream to the data of a data array.
+  /// Get the number of elements in the data array.
+  auto array_size(DataArrayID array_id) const -> size_t;
+
+  /// Open an output stream to write the data of a data array.
   /// @{
   auto array_data_open_write(DataArrayID array_id) -> OutputStreamPtr<byte_t>;
   template<known_type_of Val>
@@ -519,7 +557,7 @@ public:
   }
   /// @}
 
-  /// Open an input stream to the data of a data array.
+  /// Open an input stream to read the data of a data array.
   /// @{
   auto array_data_open_read(DataArrayID array_id) const
       -> InputStreamPtr<byte_t>;
@@ -527,19 +565,6 @@ public:
   auto array_data_open_read(DataArrayID array_id) const -> InputStreamPtr<Val> {
     TIT_ASSERT(array_type(array_id) == type_of<Val>, "Type mismatch!");
     return make_stream_deserializer<Val>(array_data_open_read(array_id));
-  }
-  /// @}
-
-  /// Get the data of a data array.
-  /// @{
-  auto array_data(DataArrayID array_id) const -> std::vector<byte_t>;
-  template<known_type_of Val>
-  auto array_data(DataArrayID array_id) const -> std::vector<Val> {
-    std::vector<Val> result;
-    read_from(array_data_open_read<Val>(array_id),
-              result,
-              /*chunk_size=*/(64 * 1024UZ / sizeof(Val)));
-    return result;
   }
   /// @}
 

--- a/source/tit/data/type.hpp
+++ b/source/tit/data/type.hpp
@@ -15,6 +15,7 @@
 #include "tit/core/basic_types.hpp"
 #include "tit/core/exception.hpp"
 #include "tit/core/mat.hpp"
+#include "tit/core/math.hpp"
 #include "tit/core/utils.hpp"
 #include "tit/core/vec.hpp"
 
@@ -217,6 +218,11 @@ public:
   /// Data type dimensionality. Always 1 for scalars.
   constexpr auto dim() const noexcept -> size_t {
     return dim_;
+  }
+
+  /// Data type width (in bytes).
+  constexpr auto width() const -> size_t {
+    return kind().width() * ipow(dim(), std::to_underlying(rank()));
   }
 
   /// Data type string representation.

--- a/source/tit/data/type.test.cpp
+++ b/source/tit/data/type.test.cpp
@@ -49,6 +49,7 @@ TEST_CASE("data::DataType") {
       CHECK(type.kind() == data::kind_of<float32_t>);
       CHECK(type.rank() == data::DataRank::scalar);
       CHECK(type.dim() == 1);
+      CHECK(type.width() == 4);
       CHECK(type.name() == "float32_t");
     }
     SUBCASE("vector") {
@@ -58,6 +59,7 @@ TEST_CASE("data::DataType") {
       CHECK(type.kind() == data::kind_of<float64_t>);
       CHECK(type.rank() == data::DataRank::vector);
       CHECK(type.dim() == 2);
+      CHECK(type.width() == 2 * 8);
       CHECK(type.name() == "Vec<float64_t, 2>");
     }
     SUBCASE("matrix") {
@@ -67,6 +69,7 @@ TEST_CASE("data::DataType") {
       CHECK(type.kind() == data::kind_of<int16_t>);
       CHECK(type.rank() == data::DataRank::matrix);
       CHECK(type.dim() == 3);
+      CHECK(type.width() == 3 * 3 * 2);
       CHECK(type.name() == "Mat<int16_t, 3>");
     }
   }


### PR DESCRIPTION
In this PR I rework `tit::data`.

- [x] Rework data types. Data kind must be a separate full-featured entity  (0e3d856bc1f1bc7929b9565124143620ac24145b).
- [x] Input streams as ranges.
- [x] Storage series, time steps of a series, etc., should be accessed via streams. We should not read everything into a huge vectors and assume everything would perform fine.
- [x] Reading/writing streams into containers should be implemented in the stream class, and not by the storage.
- [x] We should store decompressed size of the data arrays. This is useful to pre-allocate the memory once we read those.
- [ ] We should implement NumPy arrays IO via streams (from storage), likely in a separate PR.