### PR TITLE
Upgrade oneTBB to the latest version (2022.0).

### DIFF
--- a/build/setup-ci-runner.sh
+++ b/build/setup-ci-runner.sh
@@ -102,8 +102,7 @@ install-vcpkg() {
   export VCPKG_DEFAULT_BINARY_CACHE="$HOME/vcpkg_cache"
   echo "VCPKG_ROOT=$VCPKG_ROOT" >> "$GITHUB_ENV"
   echo "VCPKG_DEFAULT_BINARY_CACHE=$VCPKG_DEFAULT_BINARY_CACHE" >> "$GITHUB_ENV"
-  # Note: we cannot use `--depth=1` here, vcpgk requires the baseline commit.
-  git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+  git clone https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT" --depth=1
   "$VCPKG_ROOT/bootstrap-vcpkg.sh"
   mkdir -p "$VCPKG_DEFAULT_BINARY_CACHE" || true # Ignore if it already exists.
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "tit",
   "version-string": "0.1.0",
-  "builtin-baseline": "9d163f0612f75a49133cfd051f0ed997a24602d5",
   "dependencies": [
     "boost-container",
     "boost-core",
@@ -19,6 +18,5 @@
     "sqlite3",
     "tbb",
     "zstd"
-  ],
-  "overrides": [{ "name": "tbb", "version": "2021.13.0" }]
+  ]
 }


### PR DESCRIPTION
oneTBB 2022.0 was patched in vcpkg that fixes compilation on macOS and GCC, so, we can finally upgrade.