### PR TITLE
Python targets and linting.

### DIFF
--- a/.github/actions/setup_runner/action.yml
+++ b/.github/actions/setup_runner/action.yml
@@ -42,8 +42,10 @@ runs:
           "gcc@$GCC_VERSION"
           gcovr
           "llvm@$LLVM_VERSION"
+          mypy
           node
           pnpm
+          pylint
           sphinx-doc
         )
         if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -115,6 +117,7 @@ runs:
         # Select packages to install.
         PYTHON_PACKAGES=(
           coverage
+          Flake8-pyproject
           numpy
         )
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 !tsconfig*.json
 
 # Python configuration files.
+!py.typed
 !/pyproject.toml
 
 # Output.

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -4,10 +4,11 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 include_guard()
+include(utils)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# Find the Python interpreter executable.
+# Find Python interpreter.
 find_program(PYTHON_EXE NAMES "python3" REQUIRED)
 
 # Find the coverage.py executable.
@@ -15,5 +16,126 @@ find_program(COVERAGE_EXE NAMES "coverage" REQUIRED)
 
 # Setup Python run command.
 set(PYTHON_RUN_CMD "$<IF:$<CONFIG:Coverage>,${COVERAGE_EXE} run,${PYTHON_EXE}>")
+
+# Setup Python path.
+set(PYTHON_PATH "${CMAKE_SOURCE_DIR}/source:$ENV{PYTHONPATH}")
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Find the Flake8 executable.
+find_program(FLAKE8_EXE NAMES "flake8")
+
+# Define Flake8 run options.
+set(
+  FLAKE8_OPTIONS
+  "--toml-config=${CMAKE_SOURCE_DIR}/pyproject.toml"
+)
+list(JOIN FLAKE8_OPTIONS " " FLAKE8_OPTIONS)
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Find the Pylint executable.
+find_program(PYLINT_EXE NAMES "pylint")
+
+# Define Pylint run options.
+set(
+  PYLINT_OPTIONS
+  "--rcfile=${CMAKE_SOURCE_DIR}/pyproject.toml"
+  "--score=False"
+  "--persistent=False"
+  "--output-format=colorized"
+)
+list(JOIN PYLINT_OPTIONS " " PYLINT_OPTIONS)
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Find the MyPy executable.
+find_program(MYPY_EXE NAMES "mypy")
+
+# Define MyPy run options.
+set(
+  MYPY_OPTIONS
+  "--config-file=${CMAKE_SOURCE_DIR}/pyproject.toml"
+)
+list(JOIN MYPY_OPTIONS " " MYPY_OPTIONS)
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#
+# Add a Python target.
+#
+function(add_tit_python_target)
+  # Parse and check arguments.
+  cmake_parse_arguments(TARGET "" "NAME;DESTINATION" "SOURCES" ${ARGN})
+  if(NOT TARGET_NAME)
+    message(FATAL_ERROR "Python module name must be specified.")
+  endif()
+
+  # Create the target.
+  # This will be a no-op target, since we are not compiling Python code anyhow.
+  make_target_name("${TARGET_NAME}" TARGET)
+  add_custom_target("${TARGET}" ALL DEPENDS "${TARGET_SOURCES}")
+
+  # Run linters.
+  if(NOT SKIP_ANALYSIS AND (FLAKE8_EXE OR PYLINT_EXE OR MYPY_EXE))
+    set(ALL_STAMPS)
+    foreach(SOURCE ${TARGET_SOURCES})
+      # We'll need a stamp file to track the analysis.
+      string(REPLACE "/" "_" STAMP "${SOURCE}.stamp")
+      set(STAMP "${CMAKE_CURRENT_BINARY_DIR}/${STAMP}")
+      list(APPEND ALL_STAMPS "${STAMP}")
+
+      # Locate the source file.
+      if(NOT EXISTS "${SOURCE}")
+        set(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE}")
+        if(NOT EXISTS "${SOURCE}")
+          message(WARNING "Source file '${SOURCE}' cannot be found.")
+          continue()
+        endif()
+      endif()
+
+      # Setup the lint command.
+      set(LINT_COMMAND)
+      if(FLAKE8_EXE)
+        list(APPEND LINT_COMMAND "${FLAKE8_EXE} ${SOURCE} ${FLAKE8_OPTIONS}")
+      endif()
+      if(PYLINT_EXE)
+        list(APPEND LINT_COMMAND "${PYLINT_EXE} ${SOURCE} ${PYLINT_OPTIONS}")
+      endif()
+      if(MYPY_EXE)
+        list(APPEND LINT_COMMAND "${MYPY_EXE} ${SOURCE} ${MYPY_OPTIONS}")
+      endif()
+      list(JOIN LINT_COMMAND " && " LINT_COMMAND)
+
+      # Run the linters and update a stamp file on success.
+      cmake_path(
+        RELATIVE_PATH SOURCE
+        BASE_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        OUTPUT_VARIABLE RELATIVE_SOURCE_PATH
+      )
+      add_custom_command(
+        COMMENT "Linting ${RELATIVE_SOURCE_PATH}"
+        OUTPUT "${STAMP}"
+        COMMAND
+          "${CMAKE_COMMAND}" -E env "PYTHONPATH=${PYTHON_PATH}"
+              "${CHRONIC_EXE}" "${SHELL_EXE}" -c "${LINT_COMMAND}"
+        COMMAND
+          "${CMAKE_COMMAND}" -E touch "${STAMP}"
+        DEPENDS "${SOURCE}" "${CMAKE_SOURCE_DIR}/pyproject.toml"
+        VERBATIM
+      )
+    endforeach()
+    add_custom_target("${TARGET}_lint" ALL DEPENDS ${TARGET} ${ALL_STAMPS})
+  endif()
+
+  # Install the target.
+  if(TARGET_DESTINATION)
+    install_each_file(
+      DESTINATION "${TARGET_DESTINATION}"
+      BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+      FILES ${TARGET_SOURCES}
+    )
+  endif()
+endfunction()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -4,6 +4,8 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 include_guard()
+include(tit_target)
+include(utils)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -36,7 +38,7 @@ function(add_tit_test)
     TEST
     ""
     "NAME;EXIT_CODE;STDIN;MATCH_STDOUT;MATCH_STDERR"
-    "EXE;COMMAND;ENVIRONMENT;INPUT_FILES;MATCH_FILES;FILTERS;FLAGS"
+    "EXE;PYTHON;COMMAND;ENVIRONMENT;INPUT_FILES;MATCH_FILES;FILTERS;FLAGS"
     ${ARGN}
   )
 
@@ -53,33 +55,52 @@ function(add_tit_test)
   endif()
 
   # Setup the test command.
-  if(TEST_EXE)
+  if(TEST_EXE OR TEST_PYTHON)
     if(TEST_COMMAND)
-      message(FATAL_ERROR "Cannot specify both 'EXE' and 'COMMAND' arguments.")
+      message(FATAL_ERROR "'EXE', 'PYTHON', 'COMMAND' are mutually exclusive.")
     endif()
-    cmake_parse_arguments(TEST "" "" "SOURCES;DEPENDS" ${TEST_EXE})
 
     # Setup the target name.
     string(REPLACE "/" "_" TEST_TARGET "${TEST_NAME}")
     set(TEST_TARGET "${TEST_TARGET}_test")
 
-    # Setup the list of sources and dependencies. Since `test.cmake` files
-    # are included in the root test directory, we need to provide the
-    # absolute paths to the sources.
-    if(NOT TEST_SOURCES)
-      message(FATAL_ERROR "List of 'EXE' test sources must not be empty.")
+    if(TEST_EXE)
+      cmake_parse_arguments(TEST "" "" "SOURCES;DEPENDS" ${TEST_EXE})
+
+      # Setup the list of sources and dependencies. Since `test.cmake` files
+      # are included in the root test directory, we need to provide the
+      # absolute paths to the sources.
+      if(NOT TEST_SOURCES)
+        message(FATAL_ERROR "List of 'EXE' test sources must not be empty.")
+      endif()
+      list(TRANSFORM TEST_SOURCES PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
+
+      # Add the executable.
+      add_tit_executable(
+        NAME "${TEST_TARGET}"
+        SOURCES ${TEST_SOURCES}
+        DEPENDS ${TEST_DEPENDS}
+      )
+
+      # Test command will run the executable.
+      set(TEST_COMMAND "${TEST_TARGET}")
+    elseif(TEST_PYTHON)
+      cmake_parse_arguments(TEST "" "SOURCE" "" ${TEST_PYTHON})
+
+      # Same as for the 'EXE' case, but we have a single source file.
+      # Also, we need to add the source file to the list of input files.
+      if(NOT TEST_SOURCE)
+        message(FATAL_ERROR "Single 'PYTHON' test source must be provided.")
+      endif()
+      list(PREPEND TEST_INPUT_FILES "${TEST_SOURCE}")
+      set(TEST_SOURCE "${CMAKE_CURRENT_LIST_DIR}/${TEST_SOURCE}")
+
+      # Add the Python module.
+      add_tit_python_target(NAME "${TEST_TARGET}" SOURCES "${TEST_SOURCE}")
+
+      # Test command will run the Python script.
+      set(TEST_COMMAND "${SHELL_EXE}" -c "${PYTHON_RUN_CMD} ${TEST_SOURCE}")
     endif()
-    list(TRANSFORM TEST_SOURCES PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
-
-    # Add the executable.
-    add_tit_executable(
-      NAME "${TEST_TARGET}"
-      SOURCES ${TEST_SOURCES}
-      DEPENDS ${TEST_DEPENDS}
-    )
-
-    # Test command will run the executable.
-    set(TEST_COMMAND "${TEST_TARGET}")
   endif()
   if(NOT TEST_COMMAND)
     message(FATAL_ERROR "Command line must not be empty.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,12 @@ indent_width = 2
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [tool.flake8]
+max_line_length = 80
 ignore = [
+  "E111", # expected 2 spaces, found 4
+  "E114", # indentation is not a multiple of 4 (comment)
   "E302", # expected 2 blank lines, found 1
+  "E305", # expected 2 blank lines after class or function definition, found 1
 ]
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/titsdk/CMakeLists.txt
+++ b/source/titsdk/CMakeLists.txt
@@ -32,8 +32,10 @@ install(
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-install(
-  FILES
+add_tit_python_target(
+  NAME
+    titsdk_py
+  SOURCES
     "__init__.py"
     "lib.py"
     "ttdb.py"

--- a/source/ttdbreader/CMakeLists.txt
+++ b/source/ttdbreader/CMakeLists.txt
@@ -3,8 +3,10 @@
 # Commercial use, including SaaS, requires a separate license, see /LICENSE.md
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-install(
-  FILES
+add_tit_python_target(
+  NAME
+    ttdbreader
+  SOURCES
     "TTDBReader.py"
   DESTINATION
     "paraview/ttdbreader"

--- a/tests/titsdk/export_csv/test.cmake
+++ b/tests/titsdk/export_csv/test.cmake
@@ -4,9 +4,8 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 add_tit_test(
-  INPUT_FILES "test.py"
+  PYTHON SOURCE "test.py"
   MATCH_FILES "output.csv.checksum"
-  COMMAND "${SHELL_EXE}" -c "${PYTHON_RUN_CMD} test.py"
 )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/titsdk/invalid_ttdb/test.cmake
+++ b/tests/titsdk/invalid_ttdb/test.cmake
@@ -4,9 +4,8 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 add_tit_test(
-  INPUT_FILES "test.py"
+  PYTHON SOURCE "test.py"
   MATCH_STDOUT "stdout.txt"
-  COMMAND "${SHELL_EXE}" -c "${PYTHON_RUN_CMD} test.py"
 )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/titsdk/print_info/test.cmake
+++ b/tests/titsdk/print_info/test.cmake
@@ -4,9 +4,8 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 add_tit_test(
-  INPUT_FILES "test.py"
+  PYTHON SOURCE "test.py"
   MATCH_STDOUT "stdout.txt"
-  COMMAND "${SHELL_EXE}" -c "${PYTHON_RUN_CMD} test.py"
 )
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In this PR I introduce a bunch of CMake function to define Python targets that support automatic linting and installation (similar to C++ and PNPM targets).

**TODO**:

- [x] Split `ttdb` into `titsdk` and `ttdbreader`.
- [x] Properly configure Flake8, Pylint and MyPy.
- [x] Overall build files clean-up: naming, code duplication, string literals in `get_/set_target_property`, etc.

Also I'd like to add API reference in the user manual at some stage.
